### PR TITLE
Update Readme for jaeger-operator chart

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.12.1
+version: 2.12.2
 appVersion: 1.15.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -5,7 +5,7 @@
 ## Install
 
 ```console
-$ helm install stable/jaeger-operator
+$ helm install jaegertracing/jaeger-operator
 ```
 
 ## Introduction
@@ -18,10 +18,16 @@ This chart bootstraps a jaeger-operator deployment on a [Kubernetes](http://kube
 
 ## Installing the Chart
 
+Add the Jaeger Tracing Helm repository:
+
+```console
+$ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+```
+
 To install the chart with the release name `my-release`:
 
 ```console
-$ helm install --name my-release stable/jaeger-operator
+$ helm install --name my-release jaegertracing/jaeger-operator
 ```
 
 The command deploys jaeger-operator on the Kubernetes cluster in the default configuration. The [configuration](#configuration) section lists the parameters that can be configured during installation.
@@ -66,7 +72,7 @@ Specify each parameter you'd like to override using a YAML file as described abo
 You can also specify any non-array parameter using the `--set key=value[,key=value]` argument to `helm install`. For example,
 
 ```console
-$ helm install stable/jaeger-operator --name my-release \
+$ helm install jaegertracing/jaeger-operator --name my-release \
     --set rbac.create=false
 ```
 


### PR DESCRIPTION
Testing gh actions for jaeger-operator chart README update. This needs to happen anyway, but I wanted to wait till GitHub Actions CI was set up and running before making PRs. This chart should pass CI.

Signed-off-by: Scott Rigby <scott@r6by.com>