### PR TITLE
Updated charts to use v1.16.0

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.12.2
-appVersion: 1.15.1
+version: 2.12.3
+appVersion: 1.16.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 source: https://github.com/jaegertracing/jaeger-operator

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | Parameter               | Description                                                                                                 | Default                         |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.15.1`                        |
+| `image.tag`             | Controller container image tag                                                                              | `1.16.0`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.15.1
+  tag: 1.16.0
   pullPolicy: IfNotPresent
 
 crd:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.15.1
+appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.5
+version: 0.17.6
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -358,7 +358,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  `elastic`                               |
 | `storage.elasticsearch.nodesWanOnly`     | Only access specified es host       |  `false`                                 |
 | `storage.type`                           | Storage type (ES or Cassandra)      |  `cassandra`                             |
-| `tag`                                    | Image tag/version                   |  `1.15.1`                                 |
+| `tag`                                    | Image tag/version                   |  `1.16.0`                                 |
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -6,7 +6,7 @@ provisionDataStore:
   cassandra: true
   elasticsearch: false
 
-tag: 1.15.1
+tag: 1.16.0
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Both Jaeger and Jaeger Operator have been released today under the version 1.16.0. This PR updates the charts to use the new versions.

Signed-off-by: Juraci Paixão Kröhling <juraci@kroehling.de>