### PR TITLE
Made it possible to overwrite --reporter.grpc.host-port flag

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.15.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.4
+version: 0.17.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -49,8 +49,10 @@ spec:
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         env:
+        {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
           value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpcPort }}
+        {{- end }}
         {{- range $key, $value := .Values.agent.cmdlineParams }}
         - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
           value: {{ $value }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -109,9 +109,6 @@ agent:
   annotations: {}
   image: jaegertracing/jaeger-agent
   pullPolicy: IfNotPresent
-  collector:
-    host: null
-    port: null
   cmdlineParams: {}
   daemonset:
     useHostPort: false


### PR DESCRIPTION
It was not possible to change the --reporter.grpc.host-port to a custom hostname in case
the agent should send to a different service name.