### PR TITLE
Landing page

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+charts.jaegertracing.io

--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-charts.jaegertracing.io

--- a/_config.yml
+++ b/_config.yml
@@ -1,0 +1,3 @@
+theme: jekyll-theme-cayman
+name: Jaeger Charts
+description: Jaeger Tracing Helm Repository

--- a/index.md
+++ b/index.md
@@ -1,0 +1,25 @@
+# Jaeger Tracing Helm Repository
+
+![Jaeger](https://www.jaegertracing.io/img/jaeger-logo.png)
+
+## Add the Jaeger Tracing Helm repository
+
+```bash
+helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
+```
+
+## Install Jaeger
+
+```bash
+helm upgrade -i jaeger jaegertracing/jaeger
+```
+
+For more details on installing Jaeger please see the [chart's README](https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger).
+
+## Install Jaeger Operator
+
+```bash
+helm upgrade -i jaeger-operator jaegertracing/jaeger-operator
+```
+
+For more details on installing Jaeger Operator please see the [chart's README](https://github.com/jaegertracing/helm-charts/tree/master/charts/jaeger-operator).


### PR DESCRIPTION
Heavily inspired by @stefanprodan's  work for the Flux charts landing page, here is a PR to do this for Jaeger as well.

Is there a way of previewing this @scottrigby ?

We would need `charts.jaegertracing.io` added as a CNAME before merging

Would solve #6 
Signed-off-by: Naseem <naseemkullah@gmail.com>