### PR TITLE
[jaeger] Use official elastic chart as elasticsearch dependency

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,7 @@ jobs:
         run: |
           helm repo add stable https://kubernetes-charts.storage.googleapis.com/
           helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+          helm repo add elastic https://helm.elastic.co
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-alpha.1

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.7
+version: 0.18.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -6,75 +6,15 @@
 
 This chart adds all components required to run Jaeger as described in the [jaeger-kubernetes](https://github.com/jaegertracing/jaeger-kubernetes) GitHub page for a production-like deployment. The chart default will deploy a new Cassandra cluster (using the [cassandra chart](https://github.com/kubernetes/charts/tree/master/incubator/cassandra)), but also supports using an existing Cassandra cluster, deploying a new ElasticSearch cluster (using the [elasticsearch chart](https://github.com/kubernetes/charts/tree/master/incubator/elasticsearch)), or connecting to an existing ElasticSearch cluster. Once the back storage available, the chart will deploy jaeger-agent as a DaemonSet and deploy the jaeger-collector and jaeger-query components as standard individual deployments.
 
-## Prerequisites
-
-- Has been tested on Kubernetes 1.7+
-  - The `spark` cron job requires [K8s CronJob](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) support:
-    > You need a working Kubernetes cluster at version >= 1.8 (for CronJob). For previous versions of cluster (< 1.8) you need to explicitly enable `batch/v2alpha1` API by passing `--runtime-config=batch/v2alpha1=true` to the API server ([see Turn on or off an API version for your cluster for more](https://kubernetes.io/docs/admin/cluster-management/#turn-on-or-off-an-api-version-for-your-cluster)).
-
-- The Cassandra chart calls out the following requirements (default) for a test environment (please see the important note in the installation section):
-```
-resources:
-  requests:
-    memory: 4Gi
-    cpu: 2
-  limits:
-    memory: 4Gi
-    cpu: 2
-```
-- The Cassandra chart calls out the following requirements for a production environment:
-```
-resources:
-  requests:
-    memory: 8Gi
-    cpu: 2
-  limits:
-    memory: 8Gi
-    cpu: 2
-```
-
-- The ElasticSearch chart calls out the following requirements for a production environment:
-```
-client:
-  ...
-  resources:
-    limits:
-      cpu: "1"
-      # memory: "1024Mi"
-    requests:
-      cpu: "25m"
-      memory: "512Mi"
-
-master:
-  ...
-  resources:
-    limits:
-      cpu: "1"
-      # memory: "1024Mi"
-    requests:
-      cpu: "25m"
-      memory: "512Mi"
-
-data:
-  ...
-  resources:
-    limits:
-      cpu: "1"
-      # memory: "2048Mi"
-    requests:
-      cpu: "25m"
-      memory: "1536Mi"
-```
-
 ## Installing the Chart
 
 Add the Jaeger Tracing Helm repository:
 
-```console
+```bash
 $ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 ```
 
-To install the chart with the release name `myrel`, run the following command:
+To install the chart with the release name `jaeger`, run the following command:
 
 ```bash
 $ helm install jaeger jaegertracing/jaeger
@@ -159,9 +99,9 @@ To install the chart with the release name `jaeger` using a new ElasticSearch cl
 $ helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false  --set elasticsearch.enabled=true --set storage.type=elasticsearch
 ```
 
-## Installing the Chart using an Existing ElasticSearch Cluster
+## Installing the Chart using an Existing Elasticsearch Cluster
 
-If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store:
+A release can be configured as follows to use an existing Elasticsearch cluster as it as the storage backend:
 
 ```bash
 helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false --set storage.type=elasticsearch --set storage.elasticsearch.host=<HOST> --set storage.elasticsearch.port=<PORT> --set storage.elasticsearch.user=<USER> --set storage.elasticsearch.password=<password>
@@ -221,7 +161,7 @@ data:
 
 ```bash
 kubectl apply -f jaeger-tls-cfgmap.yaml
-helm install jaegertracing/jaeger --name myrel --values jaeger-values.yaml
+helm install jaeger jaegertracing/jaeger --values jaeger-values.yaml
 ```
 
 ## Uninstalling the Chart
@@ -278,13 +218,12 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `9411` |
 | `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
 | `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |
-| `elasticsearch.rbac.create` | To enable RBAC | `false` |
+| `elasticsearch.enable` | Install elasticsearch as a dependency | `false` |
 | `fullnameOverride` | Override full name | `nil` |
 | `hotrod.enabled` | Enables the Hotrod demo app | `false` |
 | `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
 | `nameOverride` | Override name| `nil` |
 | `provisionDataStore.cassandra` | Provision Cassandra Data Store| `true` |
-| `provisionDataStore.elasticsearch` | Provision Elasticsearch Data Store | `false` |
 | `query.agentSidecar.enabled` | Enable agent sidecare for query deployment | `true` |
 | `query.service.annotations` | Annotations for Query SVC | `nil` |
 | `query.cmdlineParams` | Additional command line parameters | `nil` |

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -96,7 +96,7 @@ helm install jaeger jaegertracing/jaeger --values values.yaml
 To install the chart with the release name `jaeger` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
 
 ```bash
-$ helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false  --set elasticsearch.enabled=true --set storage.type=elasticsearch
+$ helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true --set storage.type=elasticsearch
 ```
 
 ## Installing the Chart using an Existing Elasticsearch Cluster
@@ -218,12 +218,12 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `nil` |
 | `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
 | `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |
-| `elasticsearch.enable` | Install elasticsearch as a dependency | `false` |
 | `fullnameOverride` | Override full name | `nil` |
 | `hotrod.enabled` | Enables the Hotrod demo app | `false` |
 | `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
 | `nameOverride` | Override name| `nil` |
 | `provisionDataStore.cassandra` | Provision Cassandra Data Store| `true` |
+| `provisionDataStore.elasticsearch` | Provision Elasticsearch Data Store | `false` |
 | `query.agentSidecar.enabled` | Enable agent sidecare for query deployment | `true` |
 | `query.service.annotations` | Annotations for Query SVC | `nil` |
 | `query.cmdlineParams` | Additional command line parameters | `nil` |

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -77,7 +77,7 @@ $ helm repo add jaegertracing https://jaegertracing.github.io/helm-charts
 To install the chart with the release name `myrel`, run the following command:
 
 ```bash
-$ helm install jaegertracing/jaeger --name myrel
+$ helm install jaeger jaegertracing/jaeger
 ```
 
 After a few minutes, you should see a 3 node Cassandra instance, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
@@ -85,20 +85,16 @@ After a few minutes, you should see a 3 node Cassandra instance, a Jaeger Daemon
 IMPORTANT NOTE: For testing purposes, the footprint for Cassandra can be reduced significantly in the event resources become constrained (such as running on your local laptop or in a Vagrant environment). You can override the resources required run running this command:
 
 ```bash
-helm install jaegertracing/jaeger --name myrel --set cassandra.config.max_heap_size=1024M --set cassandra.config.heap_new_size=256M --set cassandra.resources.requests.memory=2048Mi --set cassandra.resources.requests.cpu=0.4 --set cassandra.resources.limits.memory=2048Mi --set cassandra.resources.limits.cpu=0.4
+helm install jaeger jaegertracing/jaeger --set cassandra.config.max_heap_size=1024M --set cassandra.config.heap_new_size=256M --set cassandra.resources.requests.memory=2048Mi --set cassandra.resources.requests.cpu=0.4 --set cassandra.resources.limits.memory=2048Mi --set cassandra.resources.limits.cpu=0.4
 ```
-
-> **Tip**: List all releases using `helm list`
 
 ## Installing the Chart using an Existing Cassandra Cluster
 
 If you already have an existing running Cassandra cluster, you can configure the chart as follows to use it as your backing store (make sure you replace `<HOST>`, `<PORT>`, etc with your values):
 
 ```bash
-helm install jaegertracing/jaeger --name myrel --set provisionDataStore.cassandra=false --set storage.cassandra.host=<HOST> --set storage.cassandra.port=<PORT> --set storage.cassandra.user=<USER> --set storage.cassandra.password=<PASSWORD>
+helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false --set storage.cassandra.host=<HOST> --set storage.cassandra.port=<PORT> --set storage.cassandra.user=<USER> --set storage.cassandra.password=<PASSWORD>
 ```
-
-> **Tip**: It is highly encouraged to run the Cassandra cluster with storage persistence.
 
 ## Installing the Chart using an Existing Cassandra Cluster with TLS
 
@@ -152,31 +148,24 @@ data:
 
 ```bash
 kubectl apply -f jaeger-tls-cassandra-secret.yaml
-helm install jaegertracing/jaeger --name myrel --values values.yaml
+helm install jaeger jaegertracing/jaeger --values values.yaml
 ```
 
 ## Installing the Chart using a New ElasticSearch Cluster
 
-To install the chart with the release name `myrel` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
+To install the chart with the release name `jaeger` using a new ElasticSearch cluster instead of Cassandra (default), run the following command:
 
 ```bash
-$ helm install jaegertracing/jaeger --name myrel --set provisionDataStore.cassandra=false  --set provisionDataStore.elasticsearch=true --set storage.type=elasticsearch
+$ helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false  --set elasticsearch.enabled=true --set storage.type=elasticsearch
 ```
-
-After a few minutes, you should see 2 ElasticSearch client nodes, 2 ElasticSearch data nodes, 3 ElasticSearch master nodes, a Jaeger DaemonSet, a Jaeger Collector, and a Jaeger Query (UI) pod deployed into your Kubernetes cluster.
-
-> **Tip**: If the ElasticSearch client nodes do not enter the running state, try --set elasticsearch.rbac.create=true
 
 ## Installing the Chart using an Existing ElasticSearch Cluster
 
 If you already have an existing running ElasticSearch cluster, you can configure the chart as follows to use it as your backing store:
 
 ```bash
-helm install jaegertracing/jaeger --name myrel --set provisionDataStore.cassandra=false --set provisionDataStore.elasticsearch=false --set storage.type=elasticsearch --set storage.elasticsearch.host=<HOST> --set storage.elasticsearch.port=<PORT> --set storage.elasticsearch.user=<USER> --set storage.elasticsearch.password=<password>
+helm install jaeger jaegertracing/jaeger --set provisionDataStore.cassandra=false --set storage.type=elasticsearch --set storage.elasticsearch.host=<HOST> --set storage.elasticsearch.port=<PORT> --set storage.elasticsearch.user=<USER> --set storage.elasticsearch.password=<password>
 ```
-
-> **Tip**: It is highly encouraged to run the ElasticSearch cluster with storage persistence.
-
 
 ## Installing the Chart using an Existing ElasticSearch Cluster with TLS
 

--- a/charts/jaeger/requirements.yaml
+++ b/charts/jaeger/requirements.yaml
@@ -4,6 +4,6 @@ dependencies:
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: provisionDataStore.cassandra
   - name: elasticsearch
-    version: ^1.19.1
-    repository: https://kubernetes-charts.storage.googleapis.com/
-    condition: provisionDataStore.elasticsearch
+    version: ^7.5.1
+    repository: https://helm.elastic.co
+    condition: elasticsearch.enabled

--- a/charts/jaeger/requirements.yaml
+++ b/charts/jaeger/requirements.yaml
@@ -6,4 +6,4 @@ dependencies:
   - name: elasticsearch
     version: ^7.5.1
     repository: https://helm.elastic.co
-    condition: elasticsearch.enabled
+    condition: provisionDataStore.elasticsearch

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -4,7 +4,8 @@
 
 provisionDataStore:
   cassandra: true
-  elasticsearch: false
+# To provision elasticsearch instead,
+# set above value to false and set elasticsearch.enabled to true
 
 tag: 1.16.0
 
@@ -47,7 +48,7 @@ storage:
     # existingSecret:
   elasticsearch:
     scheme: http
-    host: elasticsearch
+    host: elasticsearch-master
     port: 9200
     user: elastic
     usePassword: true
@@ -96,13 +97,10 @@ schema:
   # traceTtl: 172800
   # dependenciesTtl: 0
 
-# Begin: Override values on the Elasticsearch subchart to customize for Jaeger
+# For configurable values of the elasticsearch dependency, please see:
+# https://github.com/elastic/helm-charts/tree/master/elasticsearch#configuration
 elasticsearch:
-  cluster:
-    name: "tracing"
-  data:
-    persistence:
-      enabled: false
+  enabled: false
 
 agent:
   enabled: true

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -4,8 +4,7 @@
 
 provisionDataStore:
   cassandra: true
-# To provision elasticsearch instead,
-# set above value to false and set elasticsearch.enabled to true
+  elasticsearch: false
 
 tag: 1.16.0
 
@@ -97,10 +96,9 @@ schema:
   # traceTtl: 172800
   # dependenciesTtl: 0
 
-# For configurable values of the elasticsearch dependency, please see:
+# For configurable values of the elasticsearch if provisioned, please see:
 # https://github.com/elastic/helm-charts/tree/master/elasticsearch#configuration
-elasticsearch:
-  enabled: false
+elasticsearch: {}
 
 agent:
   enabled: true

--- a/ct.yaml
+++ b/ct.yaml
@@ -4,4 +4,5 @@ chart-dirs:
   - charts
 chart-repos:
   - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
+  - elastic=https://helm.elastic.co
 helm-extra-args: --timeout=500


### PR DESCRIPTION
Would solve #4

P.S. I also updated the README's helm install commands slightly... and removed some verbosity.

Also the condition moves form `provisionDataStore.elasticsearch` to the more standard `elasticsearch.enabled` , thoughts on that? We could do something similar once we use a different cassandra chart to depend on (https://github.com/bitnami/charts/tree/master/bitnami/cassandra seems like the best choice atm, but let's wait to see if Cassandra incubator chart gets hosted elsewhere)

Signed-off-by: Naseem <naseemkullah@gmail.com>