### PR TITLE
[jaeger] Add agent port env var

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.7
+version: 0.17.8
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.6
+version: 0.17.7
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -251,114 +251,114 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the Jaeger chart and their default values.
 
-|             Parameter                    |            Description              |                  Default               |
-|------------------------------------------|-------------------------------------|----------------------------------------|
-| `agent.annotations`                      | Annotations for Agent               |  `nil`                                   |
-| `agent.cmdlineParams`                    | Additional command line parameters  |  `nil`                                   |
-| `agent.dnsPolicy`                        | Configure DNS policy for agents     |  `ClusterFirst`                          |
-| `agent.service.annotations`              | Annotations for Agent SVC           |  `nil`                                   |
-| `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  `6832`                                  |
-| `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  `6831`                                  |
-| `agent.image`                            | Image for Jaeger Agent              |  `jaegertracing/jaeger-agent`            |
-| `agent.podAnnotations`                   | Annotations for Agent pod           |  `nil`                                   |
-| `agent.pullPolicy`                       | Agent image pullPolicy              |  `IfNotPresent`                          |
-| `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
-| `agent.service.annotations`              | Annotations for Agent SVC           |  `nil`                                   |
-| `agent.service.binaryPort`               | jaeger.thrift over binary thrift    |  `6832`                                  |
-| `agent.service.compactPort`              | jaeger.thrift over compact thrift   |  `6831`                                  |
-| `agent.service.zipkinThriftPort`         | zipkin.thrift over compact thrift   |  `5775`                                  |
-| `agent.useHostNetwork`                   | Enable hostNetwork for agents       |  `false`                                 |
-| `agent.tolerations`                      | Node Tolerations                    | `[]`                                   |
-| `collector.autoscaling.enabled`       | Enable horizontal pod autoscaling |  `false`                                   |
-| `collector.autoscaling.minReplicas`   | Minimum replicas |  2                                   |
-| `collector.autoscaling.maxReplicas`   | Maximum replicas |  10                                   |
-| `collector.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization |  80                                  |
-| `collector.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization |  `nil`                                   |
-| `collector.cmdlineParams`                | Additional command line parameters  |  `nil`                                   |
-| `collector.podAnnotations`               | Annotations for Collector pod       |  `nil`                                   |
-| `collector.service.httpPort`             | Client port for HTTP thrift         |  `14268`                                 |
-| `collector.service.annotations`          | Annotations for Collector SVC       |  `nil`                                   |
-| `collector.image`                        | Image for jaeger collector          |  `jaegertracing/jaeger-collector`        |
-| `collector.pullPolicy`                   | Collector image pullPolicy          |  `IfNotPresent`                          |
-| `collector.tolerations`                  | Node Tolerations                    | `[]`                                   |
-| `collector.service.annotations`          | Annotations for Collector SVC       |  `nil`                                   |
-| `collector.service.httpPort`             | Client port for HTTP thrift         |  `14268`                                 |
-| `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`   |
-| `collector.service.tchannelPort`         | Jaeger Agent port for thrift        |  `14267`                                 |
-| `collector.service.type`                 | Service type                        |  `ClusterIP`                             |
-| `collector.service.zipkinPort`           | Zipkin port for JSON/thrift HTTP    |  `9411`                                  |
-| `collector.extraConfigmapMounts`         | Additional collector configMap mounts |  `[]`                                  |
-| `collector.samplingConfig`         | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) |  `nil`                                  |
-| `elasticsearch.rbac.create`              | To enable RBAC                      |  `false`                                 |
-| `fullnameOverride`                       | Override full name                  |  `nil`                                 |
-| `hotrod.enabled`                         | Enables the Hotrod demo app         |  `false`                                 |
-| `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`      |
-| `nameOverride`                           | Override name                       | `nil`                                  |
-| `provisionDataStore.cassandra`           | Provision Cassandra Data Store      |  `true`                                  |
-| `provisionDataStore.elasticsearch`       | Provision Elasticsearch Data Store  |  `false`                                 |
-| `query.agentSidecar.enabled`              | Enable agent sidecare for query deployment           |  `true`                                  |
-| `query.service.annotations`              | Annotations for Query SVC           |  `nil`                                   |
-| `query.cmdlineParams`                    | Additional command line parameters  |  `nil`                                   |
-| `query.image`                            | Image for Jaeger Query UI           |  `jaegertracing/jaeger-query `           |
-| `query.ingress.enabled`                  | Allow external traffic access       |  `false`                                 |
-| `query.ingress.annotations`              | Configure annotations for Ingress   |  `{}`                                    |
-| `query.ingress.hosts`                    | Configure host for Ingress          |  `nil`                                   |
-| `query.ingress.tls`                      | Configure tls for Ingress           |  `nil`                                   |
-| `query.podAnnotations`                   | Annotations for Query pod           |  `nil`                                   |
-| `query.pullPolicy`                       | Query UI image pullPolicy           |  `IfNotPresent`                          |
-| `query.tolerations`                      | Node Tolerations                    | `[]`                                   |
-| `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]`       |
-| `query.service.port`                | External accessible port            |  `80`                                    |
-| `query.service.type`                     | Service type                        |  `ClusterIP`                             |
-| `query.basePath`                         | Base path of Query UI, used for ingress as well (if it is enabled)   |  `/`    |
-| `query.extraConfigmapMounts`             | Additional query configMap mounts   |  `[]`                                    |
-| `schema.annotations`                     | Annotations for the schema job      |  `nil`                                   |
-| `schema.extraConfigmapMounts`            | Additional cassandra schema job configMap mounts |  `[]`                                  |
-| `schema.image`                           | Image to setup cassandra schema     |  `jaegertracing/jaeger-cassandra-schema` |
-| `schema.mode`                            | Schema mode (prod or test)          |  `prod`                                  |
-| `schema.pullPolicy`                      | Schema image pullPolicy             |  `IfNotPresent`                          |
-| `schema.activeDeadlineSeconds`           | Deadline in seconds for cassandra schema creation job to complete |  `120`                            |
-| `schema.traceTtl`                     | Time to live for trace data in seconds      |  `nil`                                |
-| `schema.keyspace`                     | Set explicit keyspace name      |  `nil`                                |
-| `schema.dependenciesTtl`              | Time to live for dependencies data in seconds  |  `nil`                          |
-| `serviceAccounts.agent.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.agent.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `serviceAccounts.cassandraSchema.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.cassandraSchema.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `serviceAccounts.collector.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.collector.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `serviceAccounts.hotrod.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.hotrod.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `serviceAccounts.query.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.query.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `serviceAccounts.spark.create`              | Create service account   |  `true`                                  |
-| `serviceAccounts.spark.name`              | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template  |  ``                                  |
-| `spark.enabled`                          | Enables the dependencies job        |  `false`                                 |
-| `spark.image`                            | Image for the dependencies job      |  `jaegertracing/spark-dependencies`      |
-| `spark.pullPolicy`                       | Image pull policy of the deps image |  `Always`                                |
-| `spark.schedule`                         | Schedule of the cron job            |  `"49 23 * * *"`                         |
-| `spark.successfulJobsHistoryLimit`       | Cron job successfulJobsHistoryLimit |  `5`                                     |
-| `spark.failedJobsHistoryLimit`           | Cron job failedJobsHistoryLimit     |  `5`                                     |
-| `spark.tag`                              | Tag of the dependencies job image   |  `latest`                                |
-| `spark.tolerations`                      | Node Tolerations                    | `[]`                                   |
-| `storage.cassandra.existingSecret`                 | Name of existing password secret object (for password authentication)          |  `nil`
-| `storage.cassandra.host`                 | Provisioned cassandra host          |  `cassandra`                             |
-| `storage.cassandra.password`             | Provisioned cassandra password  (ignored if storage.cassandra.existingSecret set)     |  `password`                              |
-| `storage.cassandra.port`                 | Provisioned cassandra port          |  `9042`                                  |
-| `storage.cassandra.tls.enabled`          | Provisioned cassandra TLS connection enabled |  `false`                                    |
-| `storage.cassandra.tls.secretName`       | Provisioned cassandra TLS connection existing secret name (possible keys in secret: `ca-cert.pem`, `client-key.pem`, `client-cert.pem`, `cqlshrc`, `commonName`) |  ``                                      |
-| `storage.cassandra.usePassword`                 | Use password          |  `true`                                 |
-| `storage.cassandra.user`                 | Provisioned cassandra username      |  `user`                                  |
-| `storage.elasticsearch.existingSecret`                 | Name of existing password secret object (for password authentication)          |  `nil`                                 |
-| `storage.elasticsearch.host`             | Provisioned elasticsearch host      |  `elasticsearch`                         |
-| `storage.elasticsearch.password`         | Provisioned elasticsearch password  (ignored if storage.elasticsearch.existingSecret set)  |  `changeme`                              |
-| `storage.elasticsearch.port`             | Provisioned elasticsearch port      |  `9200`                                  |
-| `storage.elasticsearch.scheme`           | Provisioned elasticsearch scheme    |  `http`                                  |
-| `storage.elasticsearch.usePassword`                 | Use password          |  `true`                                 |
-| `storage.elasticsearch.user`             | Provisioned elasticsearch user      |  `elastic`                               |
-| `storage.elasticsearch.nodesWanOnly`     | Only access specified es host       |  `false`                                 |
-| `storage.type`                           | Storage type (ES or Cassandra)      |  `cassandra`                             |
-| `tag`                                    | Image tag/version                   |  `1.16.0`                                 |
+| Parameter | Description | Default |
+|-----------|-------------|---------|
+| `agent.annotations` | Annotations for Agent | `nil` |
+| `agent.cmdlineParams` |Additional command line parameters| `nil` |
+| `agent.dnsPolicy` | Configure DNS policy for agents | `ClusterFirst` |
+| `agent.service.annotations` | Annotations for Agent SVC | `nil` |
+| `agent.service.binaryPort` | jaeger.thrift over binary thrift | `6832` |
+| `agent.service.compactPort` | jaeger.thrift over compact thrift| `6831` |
+| `agent.image` | Image for Jaeger Agent | `jaegertracing/jaeger-agent` |
+| `agent.podAnnotations` | Annotations for Agent pod | `nil` |
+| `agent.pullPolicy` | Agent image pullPolicy | `IfNotPresent` |
+| `agent.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
+| `agent.service.annotations` | Annotations for Agent SVC | `nil` |
+| `agent.service.binaryPort` | jaeger.thrift over binary thrift | `6832` |
+| `agent.service.compactPort` | jaeger.thrift over compact thrift | `6831` |
+| `agent.service.zipkinThriftPort` | zipkin.thrift over compact thrift | `5775` |
+| `agent.useHostNetwork` | Enable hostNetwork for agents | `false` |
+| `agent.tolerations` | Node Tolerations | `[]` |
+| `collector.autoscaling.enabled` | Enable horizontal pod autoscaling | `false` |
+| `collector.autoscaling.minReplicas` | Minimum replicas |  2 |
+| `collector.autoscaling.maxReplicas` | Maximum replicas |  10 |
+| `collector.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization |  80 |
+| `collector.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `nil` |
+| `collector.cmdlineParams` | Additional command line parameters | `nil` |
+| `collector.podAnnotations` | Annotations for Collector pod | `nil` |
+| `collector.service.httpPort` | Client port for HTTP thrift | `14268` |
+| `collector.service.annotations` | Annotations for Collector SVC | `nil` |
+| `collector.image` | Image for jaeger collector | `jaegertracing/jaeger-collector` |
+| `collector.pullPolicy` | Collector image pullPolicy | `IfNotPresent` |
+| `collector.tolerations` | Node Tolerations | `[]` |
+| `collector.service.annotations` | Annotations for Collector SVC | `nil` |
+| `collector.service.httpPort` | Client port for HTTP thrift | `14268` |
+| `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
+| `collector.service.tchannelPort` | Jaeger Agent port for thrift| `14267` |
+| `collector.service.type` | Service type | `ClusterIP` |
+| `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `9411` |
+| `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
+| `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |
+| `elasticsearch.rbac.create` | To enable RBAC | `false` |
+| `fullnameOverride` | Override full name | `nil` |
+| `hotrod.enabled` | Enables the Hotrod demo app | `false` |
+| `hotrod.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
+| `nameOverride` | Override name| `nil` |
+| `provisionDataStore.cassandra` | Provision Cassandra Data Store| `true` |
+| `provisionDataStore.elasticsearch` | Provision Elasticsearch Data Store | `false` |
+| `query.agentSidecar.enabled` | Enable agent sidecare for query deployment | `true` |
+| `query.service.annotations` | Annotations for Query SVC | `nil` |
+| `query.cmdlineParams` | Additional command line parameters | `nil` |
+| `query.image` | Image for Jaeger Query UI | `jaegertracing/jaeger-query` |
+| `query.ingress.enabled` | Allow external traffic access | `false` |
+| `query.ingress.annotations` | Configure annotations for Ingress | `{}` |
+| `query.ingress.hosts` | Configure host for Ingress | `nil` |
+| `query.ingress.tls` | Configure tls for Ingress | `nil` |
+| `query.podAnnotations` | Annotations for Query pod | `nil` |
+| `query.pullPolicy` | Query UI image pullPolicy | `IfNotPresent` |
+| `query.tolerations` | Node Tolerations | `[]` |
+| `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
+| `query.service.port` | External accessible port | `80` |
+| `query.service.type` | Service type | `ClusterIP` |
+| `query.basePath` | Base path of Query UI, used for ingress as well (if it is enabled) | `/` |
+| `query.extraConfigmapMounts` | Additional query configMap mounts | `[]` |
+| `schema.annotations` | Annotations for the schema job| `nil` |
+| `schema.extraConfigmapMounts` | Additional cassandra schema job configMap mounts | `[]  |
+| `schema.image` | Image to setup cassandra schema | `jaegertracing/jaeger-cassandra-schema` |
+| `schema.mode` | Schema mode (prod or test | `prod` |
+| `schema.pullPolicy` | Schema image pullPolicy | `IfNotPresent` |
+| `schema.activeDeadlineSeconds` | Deadline in seconds for cassandra schema creation job to complete | `120` |
+| `schema.traceTtl` | Time to live for trace data in seconds | `nil` |
+| `schema.keyspace` | Set explicit keyspace name | `nil` |
+| `schema.dependenciesTtl` | Time to live for dependencies data in seconds | `nil` |
+| `serviceAccounts.agent.create` | Create service account | `true` |
+| `serviceAccounts.agent.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `serviceAccounts.cassandraSchema.create` | Create service account | `true` |
+| `serviceAccounts.cassandraSchema.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `serviceAccounts.collector.create` | Create service account | `true` |
+| `serviceAccounts.collector.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `serviceAccounts.hotrod.create` | Create service account | `true` |
+| `serviceAccounts.hotrod.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `serviceAccounts.query.create` | Create service account | `true` |
+| `serviceAccounts.query.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `serviceAccounts.spark.create` | Create service account | `true` |
+| `serviceAccounts.spark.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `spark.enabled` | Enables the dependencies job| `false` |
+| `spark.image` | Image for the dependencies job| `jaegertracing/spark-dependencies` |
+| `spark.pullPolicy` | Image pull policy of the deps image | `Always` |
+| `spark.schedule` | Schedule of the cron job | `"49 23 * * *"` |
+| `spark.successfulJobsHistoryLimit` | Cron job successfulJobsHistoryLimit | `5` |
+| `spark.failedJobsHistoryLimit` | Cron job failedJobsHistoryLimit | `5` |
+| `spark.tag` | Tag of the dependencies job image | `latest` |
+| `spark.tolerations` | Node Tolerations | `[]` |
+| `storage.cassandra.existingSecret` | Name of existing password secret object (for password authentication | `nil`
+| `storage.cassandra.host` | Provisioned cassandra host | `cassandra` |
+| `storage.cassandra.password` | Provisioned cassandra password  (ignored if storage.cassandra.existingSecret set) | `password` |
+| `storage.cassandra.port` | Provisioned cassandra port | `9042` |
+| `storage.cassandra.tls.enabled` | Provisioned cassandra TLS connection enabled | `false` |
+| `storage.cassandra.tls.secretName` | Provisioned cassandra TLS connection existing secret name (possible keys in secret: `ca-cert.pem`, `client-key.pem`, `client-cert.pem`, `cqlshrc`, `commonName`) | `` |
+| `storage.cassandra.usePassword` | Use password | `true` |
+| `storage.cassandra.user` | Provisioned cassandra username | `user` |
+| `storage.elasticsearch.existingSecret` | Name of existing password secret object (for password authentication | `nil` |
+| `storage.elasticsearch.host` | Provisioned elasticsearch host| `elasticsearch` |
+| `storage.elasticsearch.password` | Provisioned elasticsearch password  (ignored if storage.elasticsearch.existingSecret set | `changeme` |
+| `storage.elasticsearch.port` | Provisioned elasticsearch port| `9200` |
+| `storage.elasticsearch.scheme` | Provisioned elasticsearch scheme | `http` |
+| `storage.elasticsearch.usePassword` | Use password | `true` |
+| `storage.elasticsearch.user` | Provisioned elasticsearch user| `elastic` |
+| `storage.elasticsearch.nodesWanOnly` | Only access specified es host | `false` |
+| `storage.type` | Storage type (ES or Cassandra)| `cassandra` |
+| `tag` | Image tag/version | `1.16.0` |
 
 For more information about some of the tunable parameters that Cassandra provides, please visit the helm chart for [cassandra](https://github.com/kubernetes/charts/tree/master/incubator/cassandra) and the official [website](http://cassandra.apache.org/) at apache.org.
 

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -73,7 +73,7 @@ spec:
             value: "/cassandra-tls/client-cert.pem"
           - name: CASSANDRA_TLS_CA
             value: "/cassandra-tls/ca-cert.pem"
-          {{- end }}    
+          {{- end }}
           - name: CASSANDRA_KEYSPACE
             value: {{ printf "%s_%s" "jaeger_v1" .Values.cassandra.config.dc_name | quote }}
           - name: CASSANDRA_USERNAME
@@ -97,8 +97,12 @@ spec:
           - name: ES_USERNAME
             value: {{ .Values.storage.elasticsearch.user }}
           {{- end }}
+          {{- if .Values.query.basePath }}
           - name: QUERY_BASE_PATH
             value: {{ .Values.query.basePath | quote }}
+          {{- end }}
+          - name: JAEGER_AGENT_PORT
+            value: "6831"
         ports:
         - name: query
           containerPort: 16686


### PR DESCRIPTION
As an immediate workaround to https://github.com/jaegertracing/jaeger/issues/1986

P.S. Also slipped in an if statement around query basepath, in case not set, no need to add this env var.