### PR TITLE
Add env COLLECTOR_ZIPKIN_HTTP_PORT when collector.service.zipkinPort present

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.8
+version: 0.17.9
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -286,7 +286,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
 | `collector.service.tchannelPort` | Jaeger Agent port for thrift| `14267` |
 | `collector.service.type` | Service type | `ClusterIP` |
-| `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `9411` |
+| `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `nil` |
 | `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
 | `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |
 | `elasticsearch.rbac.create` | To enable RBAC | `false` |

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -55,6 +55,10 @@ spec:
           - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- if .Values.collector.service.zipkinPort }}
+          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+            value: {{ .Values.collector.service.zipkinPort | quote }}
+          {{- end }}
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
           {{- if eq .Values.storage.type "cassandra" }}
@@ -117,9 +121,11 @@ spec:
         - containerPort: 14269
           name: admin
           protocol: TCP
+        {{- if .Values.collector.service.zipkinPort }}
         - containerPort: {{ .Values.collector.service.zipkinPort }}
           name: zipkin
           protocol: TCP
+        {{- end }}
         readinessProbe:
           httpGet:
             path: /

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -27,10 +27,12 @@ spec:
     port: {{ .Values.collector.service.httpPort }}
     protocol: TCP
     targetPort: http
+{{- if .Values.collector.service.zipkinPort }}
   - name: zipkin
     port: {{ .Values.collector.service.zipkinPort }}
     protocol: TCP
     targetPort: zipkin
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     app.kubernetes.io/component: collector

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -168,7 +168,7 @@ collector:
     # httpPort: can accept spans directly from clients in jaeger.thrift format
     httpPort: 14268
     # can accept Zipkin spans in JSON or Thrift
-    zipkinPort: 9411
+    # zipkinPort: 9411
   resources: {}
     # limits:
     #   cpu: 1


### PR DESCRIPTION
Collector will not listen Zipkin port without the environment variable.