### PR TITLE
[jaeger] refactor service accounts

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.17.9
+version: 0.17.10
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -35,10 +35,10 @@ Create chart name and version as used by the chart label.
 Create the name of the cassandra schema service account to use
 */}}
 {{- define "jaeger.cassandraSchema.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.cassandraSchema.create -}}
-    {{ default (printf "%s-cassandra-schema" (include "jaeger.fullname" .)) .Values.serviceAccounts.cassandraSchema.name }}
+{{- if .Values.schema.serviceAccount.create -}}
+    {{ default (printf "%s-cassandra-schema" (include "jaeger.fullname" .)) .Values.schema.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.cassandraSchema.name }}
+    {{ default "default" .Values.schema.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -46,10 +46,10 @@ Create the name of the cassandra schema service account to use
 Create the name of the spark service account to use
 */}}
 {{- define "jaeger.spark.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.spark.create -}}
-    {{ default (printf "%s-spark" (include "jaeger.fullname" .)) .Values.serviceAccounts.spark.name }}
+{{- if .Values.spark.serviceAccount.create -}}
+    {{ default (printf "%s-spark" (include "jaeger.fullname" .)) .Values.spark.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.spark.name }}
+    {{ default "default" .Values.spark.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -57,10 +57,10 @@ Create the name of the spark service account to use
 Create the name of the hotrod service account to use
 */}}
 {{- define "jaeger.hotrod.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.hotrod.create -}}
-    {{ default (printf "%s-hotrod" (include "jaeger.fullname" .)) .Values.serviceAccounts.hotrod.name }}
+{{- if .Values.hotrod.serviceAccount.create -}}
+    {{ default (printf "%s-hotrod" (include "jaeger.fullname" .)) .Values.hotrod.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.hotrod.name }}
+    {{ default "default" .Values.hotrod.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -68,10 +68,10 @@ Create the name of the hotrod service account to use
 Create the name of the query service account to use
 */}}
 {{- define "jaeger.query.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.query.create -}}
-    {{ default (include "jaeger.query.name" .) .Values.serviceAccounts.query.name }}
+{{- if .Values.query.serviceAccount.create -}}
+    {{ default (include "jaeger.query.name" .) .Values.query.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.query.name }}
+    {{ default "default" .Values.query.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -79,10 +79,10 @@ Create the name of the query service account to use
 Create the name of the agent service account to use
 */}}
 {{- define "jaeger.agent.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.agent.create -}}
-    {{ default (include "jaeger.agent.name" .) .Values.serviceAccounts.agent.name }}
+{{- if .Values.agent.serviceAccount.create -}}
+    {{ default (include "jaeger.agent.name" .) .Values.agent.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.agent.name }}
+    {{ default "default" .Values.agent.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -90,10 +90,10 @@ Create the name of the agent service account to use
 Create the name of the collector service account to use
 */}}
 {{- define "jaeger.collector.serviceAccountName" -}}
-{{- if .Values.serviceAccounts.collector.create -}}
-    {{ default (include "jaeger.collector.name" .) .Values.serviceAccounts.collector.name }}
+{{- if .Values.collector.serviceAccount.create -}}
+    {{ default (include "jaeger.collector.name" .) .Values.collector.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.serviceAccounts.collector.name }}
+    {{ default "default" .Values.collector.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/jaeger/templates/agent-sa.yaml
+++ b/charts/jaeger/templates/agent-sa.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.agent.enabled .Values.serviceAccounts.agent.create -}}
+{{- if and .Values.agent.enabled .Values.agent.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ template "jaeger.agent.name" . }}
+  name: {{ template "jaeger.agent.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     helm.sh/chart: {{ include "jaeger.chart" . }}

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -24,7 +24,7 @@ spec:
 {{ toYaml .Values.schema.podLabels | indent 8 }}
 {{- end }}
     spec:
-      serviceAccountName: {{ include "jaeger.fullname" . }}-cassandra-schema
+      serviceAccountName: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-cassandra-schema
         image: {{ .Values.schema.image }}:{{ .Values.tag }}

--- a/charts/jaeger/templates/cassandra-schema-sa.yaml
+++ b/charts/jaeger/templates/cassandra-schema-sa.yaml
@@ -1,8 +1,8 @@
-{{- if and (eq .Values.storage.type "cassandra") .Values.serviceAccounts.cassandraSchema.create -}}
+{{- if and (eq .Values.storage.type "cassandra") .Values.schema.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: {{ include "jaeger.cassandraSchema.serviceAccountName" . }}
+  name: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
   labels:
     app.kubernetes.io/name: {{ include "jaeger.name" . }}
     helm.sh/chart: {{ include "jaeger.chart" . }}

--- a/charts/jaeger/templates/collector-sa.yaml
+++ b/charts/jaeger/templates/collector-sa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.collector.enabled .Values.serviceAccounts.collector.create -}}
+{{- if and .Values.collector.enabled .Values.collector.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/jaeger/templates/hotrod-sa.yaml
+++ b/charts/jaeger/templates/hotrod-sa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.hotrod.enabled .Values.serviceAccounts.hotrod.create -}}
+{{- if and .Values.hotrod.enabled .Values.hotrod.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/jaeger/templates/query-sa.yaml
+++ b/charts/jaeger/templates/query-sa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.query.enabled .Values.serviceAccounts.query.create -}}
+{{- if and .Values.query.enabled .Values.query.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/jaeger/templates/spark-sa.yaml
+++ b/charts/jaeger/templates/spark-sa.yaml
@@ -1,4 +1,4 @@
-{{- if and .Values.spark.enabled .Values.serviceAccounts.spark.create -}}
+{{- if and .Values.spark.enabled .Values.spark.serviceAccount.create -}}
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -11,26 +11,6 @@ tag: 1.16.0
 nameOverride: ""
 fullnameOverride: ""
 
-serviceAccounts:
-  cassandraSchema:
-    create: true
-    name:
-  agent:
-    create: true
-    name:
-  collector:
-    create: true
-    name:
-  query:
-    create: true
-    name:
-  spark:
-    create: true
-    name:
-  hotrod:
-    create: true
-    name:
-
 storage:
   # allowed values (cassandra, elasticsearch)
   type: cassandra
@@ -88,6 +68,9 @@ schema:
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
@@ -132,6 +115,9 @@ agent:
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
   nodeSelector: {}
   podAnnotations: {}
   ## Additional pod labels
@@ -176,6 +162,9 @@ collector:
     # requests:
     #   cpu: 500m
     #   memory: 512Mi
+  serviceAccount:
+    create: true
+    name:
   nodeSelector: {}
   podAnnotations: {}
   ## Additional pod labels
@@ -259,6 +248,9 @@ query:
     # requests:
     #    cpu: 256m
     #    memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
   nodeSelector: {}
   podAnnotations: {}
   ## Additional pod labels
@@ -290,6 +282,9 @@ spark:
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
   nodeSelector: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -336,6 +331,9 @@ hotrod:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
   tracing:
     host: null
     port: 6831


### PR DESCRIPTION
When service accounts were originally added, the helm documentation regarding best practices on sa creation for multiple components was wrong. It has since been corrected and this approach follows the correct method

Signed-off-by: Naseem <naseemkullah@gmail.com>