### PR TITLE
[jaeger-operator]: update jaeger crd to include status resource

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.12.3
+version: 2.12.4
 appVersion: 1.16.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -8,6 +8,15 @@ metadata:
   labels:
     app: jaeger-operator
 spec:
+  additionalPrinterColumns:
+  - JSONPath: .status.phase
+    description: Jaeger instance's status
+    name: Status
+    type: string
+  - JSONPath: .status.version
+    description: Jaeger Version
+    name: Version
+    type: string
   group: jaegertracing.io
   names:
     kind: Jaeger
@@ -15,6 +24,8 @@ spec:
     plural: jaegers
     singular: jaeger
   scope: Namespaced
+  subresources:
+    status: {}
   version: v1
   versions:
     - name: v1


### PR DESCRIPTION
CRD changes from [#802](https://github.com/jaegertracing/jaeger-operator/pull/802) should be merged into operator helm chart as currently the following errors are seen on logs:
```
time="2019-12-29T09:56:25Z" level=error msg="failed to store the running status into the current CustomResource" error="the server could not find the requested resource (put jaegers.jaegertracing.io jaeger-operator-jaeger)" execution="2019-12-29 09:56:24.974520864 +0000 UTC" instance=jaeger-operator-jaeger namespace=observability
time="2019-12-29T10:12:40Z" level=error msg="failed to store the running status into the current CustomResource" error="the server could not find the requested resource (put jaegers.jaegertracing.io jaeger-operator-jaeger)" execution="2019-12-29 10:12:40.637487009 +0000 UTC" instance=jaeger-operator-jaeger namespace=observability
time="2019-12-29T10:13:05Z" level=error msg="failed to store the running status into the current CustomResource" error="the server could not find the requested resource (put jaegers.jaegertracing.io jaeger-operator-jaeger)" execution="2019-12-29 10:13:05.029591192 +0000 UTC" instance=jaeger-operator-jaeger namespace=observability
```