### PR TITLE
[jaeger] Add security context to deployment charts in jaeger

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.19.0
+version: 0.19.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -185,6 +185,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `<component>.nodeSelector` | Node selector | {} |
 | `<component>.tolerations` | Node tolerations | [] |
 | `<component.affinity` | Affinity | {} |
+| `<component>.podSecurityContext` | Pod security context | {} |
+| `<component>.securityContext` | Container security context | {} |
 | `agent.annotations` | Annotations for Agent | `nil` |
 | `agent.cmdlineParams` |Additional command line parameters| `nil` |
 | `agent.dnsPolicy` | Configure DNS policy for agents | `ClusterFirst` |

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -28,6 +28,8 @@ spec:
 {{ toYaml .Values.agent.podLabels | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.agent.podSecurityContext | indent 8 }}
       {{- if .Values.agent.useHostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -35,6 +37,8 @@ spec:
       serviceAccountName: {{ template "jaeger.agent.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.agent.name" . }}
+        securityContext:
+{{ toYaml .Values.agent.securityContext | indent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         env:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -34,9 +34,13 @@ spec:
 {{ toYaml .Values.collector.podLabels | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.collector.podSecurityContext | indent 8 }}
       serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
+        securityContext:
+{{ toYaml .Values.collector.securityContext | indent 10 }}
         image: {{ .Values.collector.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         env:

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -18,9 +18,13 @@ spec:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: hotrod
     spec:
+      securityContext:
+{{ toYaml .Values.hotrod.podSecurityContext | indent 8 }}
       serviceAccountName: {{ template "jaeger.hotrod.serviceAccountName" . }}
       containers:
         - name: {{ include "jaeger.fullname" . }}-hotrod
+          securityContext:
+{{ toYaml .Values.hotrod.securityContext | indent 12 }}
           image: {{ .Values.hotrod.image.repository }}:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
           env:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -33,6 +33,8 @@ spec:
 {{ toYaml .Values.ingester.podLabels | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.ingester.podSecurityContext | indent 8 }}
       nodeSelector:
 {{ toYaml .Values.ingester.nodeSelector | indent 8 }}
 {{- if .Values.ingester.tolerations }}
@@ -41,6 +43,8 @@ spec:
 {{- end }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-ingester
+        securityContext:
+{{ toYaml .Values.ingester.securityContext | indent 10 }}
         image: {{ .Values.ingester.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
         env:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -31,9 +31,13 @@ spec:
 {{ toYaml .Values.query.podLabels | indent 8 }}
 {{- end }}
     spec:
+      securityContext:
+{{ toYaml .Values.query.podSecurityContext | indent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.query.name" . }}
+        securityContext:
+{{ toYaml .Values.query.securityContext | indent 10 }}
         image: {{ .Values.query.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         env:
@@ -134,6 +138,8 @@ spec:
             port: admin
 {{- if .Values.query.agentSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-sidecar
+        securityContext:
+{{ toYaml .Values.query.securityContext | indent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         env:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -100,6 +100,8 @@ elasticsearch: {}
 
 ingester:
   enabled: false
+  podSecurityContext: {}
+  securityContext: {}
   annotations: {}
   image: jaegertracing/jaeger-ingester
   pullPolicy: IfNotPresent
@@ -138,6 +140,8 @@ ingester:
   extraConfigmapMounts: []
 
 agent:
+  podSecurityContext: {}
+  securityContext: {}
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
@@ -191,6 +195,8 @@ agent:
   dnsPolicy: ClusterFirst
 
 collector:
+  podSecurityContext: {}
+  securityContext: {}
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
@@ -279,6 +285,8 @@ collector:
 
 query:
   enabled: true
+  podSecurityContext: {}
+  securityContext: {}
   agentSidecar:
     enabled: true
   annotations: {}
@@ -360,6 +368,8 @@ spark:
 
 hotrod:
   enabled: false
+  podSecurityContext: {}
+  securityContext: {}
   replicaCount: 1
   image:
     repository: jaegertracing/example-hotrod


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

When deploying this chart in our cluster we found that we had to add security context to the deployments for them to run as non-root user.
So i created this PR where securityContext is added to the template/charts for deployment and its default value is provided in `values.yaml` file. These can be overwritten if someone uses jaeger chart as a dependency in their own values.yaml file.