### PR TITLE
Added cassandra auth variables in spark job

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.19.2
+version: 0.19.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -218,11 +218,8 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- $host := printf "%s" .Values.storage.elasticsearch.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
 {{- else }}
-{{- $host := printf "%s-%s-%s" .Release.Name "elasticsearch" "client" | trunc 63 | trimSuffix "-" -}}
-{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
-{{- end -}}
-{{- else }}
 {{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme .Values.storage.elasticsearch.host $port }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -31,6 +31,10 @@ spec:
             image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}
             imagePullPolicy: {{ .Values.spark.pullPolicy }}
             env:
+            {{- range $key, $value := .Values.spark.cmdlineParams }}
+            - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
+            value: {{ $value | quote }}
+            {{- end }}
             - name: STORAGE
               value: {{ .Values.storage.type }}
             {{- if eq .Values.storage.type "cassandra" }}
@@ -38,6 +42,15 @@ spec:
               value: {{ template "cassandra.contact_points" . }}
             - name: CASSANDRA_KEYSPACE
               value: {{ .Values.storage.cassandra.keyspace }}
+            {{- if .Values.storage.cassandra.usePassword }}
+            - name: CASSANDRA_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
+                  key: password
+            {{- end }}
+            - name: CASSANDRA_USERNAME
+              value: {{ .Values.storage.cassandra.user }}
             {{- end }}
             {{- if eq .Values.storage.type "elasticsearch" }}
             - name: ES_NODES

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -345,6 +345,7 @@ spark:
   image: jaegertracing/spark-dependencies
   tag: latest
   pullPolicy: Always
+  cmdlineParams: {}
   schedule: "49 23 * * *"
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5


### PR DESCRIPTION
 - cassandra auth variables were missing in spark job
    cmdlineParams were also missing

 - fixed section {{- define "elasticsearch.client.url" -}} in helpers
    it was generating wrong url