### PR TITLE
[jaeger] Add ability to manually set nodeport for jaeger-collector

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.16.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.19.8
+version: 0.19.9
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -257,16 +257,15 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `nil` |
 | `collector.cmdlineParams` | Additional command line parameters | `nil` |
 | `collector.podAnnotations` | Annotations for Collector pod | `nil` |
-| `collector.service.httpPort` | Client port for HTTP thrift | `14268` |
-| `collector.service.annotations` | Annotations for Collector SVC | `nil` |
 | `collector.image` | Image for jaeger collector | `jaegertracing/jaeger-collector` |
 | `collector.pullPolicy` | Collector image pullPolicy | `IfNotPresent` |
 | `collector.service.annotations` | Annotations for Collector SVC | `nil` |
-| `collector.service.httpPort` | Client port for HTTP thrift | `14268` |
+| `collector.service.grpc.port` | Jaeger Agent port for model.proto | `14250` |
+| `collector.service.http.port` | Client port for HTTP thrift | `14268` |
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
-| `collector.service.tchannelPort` | Jaeger Agent port for thrift| `14267` |
+| `collector.service.tchannel.port` | Jaeger Agent port for thrift| `14267` |
 | `collector.service.type` | Service type | `ClusterIP` |
-| `collector.service.zipkinPort` | Zipkin port for JSON/thrift HTTP | `nil` |
+| `collector.service.zipkin.port` | Zipkin port for JSON/thrift HTTP | `nil` |
 | `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
 | `collector.extraSecretMounts` | Additional collector secret mounts | `[]` |
 | `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -44,7 +44,7 @@ spec:
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
-          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpcPort }}
+          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
         {{- range $key, $value := .Values.agent.cmdlineParams }}
         - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -48,9 +48,9 @@ spec:
           - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
             value: {{ $value | quote }}
           {{- end }}
-          {{- if .Values.collector.service.zipkinPort }}
+          {{- if .Values.collector.service.zipkin }}
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
-            value: {{ .Values.collector.service.zipkinPort | quote }}
+            value: {{ .Values.collector.service.zipkin.port | quote }}
           {{- end }}
           {{- if .Values.ingester.enabled }}
           - name: SPAN_STORAGE_TYPE
@@ -117,20 +117,20 @@ spec:
             value: /etc/conf/strategies.json
           {{- end }}
         ports:
-        - containerPort: {{ .Values.collector.service.grpcPort }}
+        - containerPort: {{ .Values.collector.service.grpc.port }}
           name: grpc
           protocol: TCP
-        - containerPort: {{ .Values.collector.service.tchannelPort }}
+        - containerPort: {{ .Values.collector.service.tchannel.port }}
           name: tchannel
           protocol: TCP
-        - containerPort: {{ .Values.collector.service.httpPort }}
+        - containerPort: {{ .Values.collector.service.http.port }}
           name: http
           protocol: TCP
         - containerPort: 14269
           name: admin
           protocol: TCP
-        {{- if .Values.collector.service.zipkinPort }}
-        - containerPort: {{ .Values.collector.service.zipkinPort }}
+        {{- if .Values.collector.service.zipkin }}
+        - containerPort: {{ .Values.collector.service.zipkin.port }}
           name: zipkin
           protocol: TCP
         {{- end }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -13,20 +13,32 @@ metadata:
 spec:
   ports:
   - name: grpc
-    port: {{ .Values.collector.service.grpcPort }}
+    port: {{ .Values.collector.service.grpc.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.grpc.nodePort) }}
+    nodePort: {{ .Values.collector.service.grpc.nodePort }}
+{{- end }}
     protocol: TCP
     targetPort: grpc
   - name: tchannel
-    port: {{ .Values.collector.service.tchannelPort }}
+    port: {{ .Values.collector.service.tchannel.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.tchannel.nodePort) }}
+    nodePort: {{ .Values.collector.service.tchannel.nodePort }}
+{{- end }}
     protocol: TCP
     targetPort: tchannel
   - name: http
-    port: {{ .Values.collector.service.httpPort }}
+    port: {{ .Values.collector.service.http.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.http.nodePort) }}
+    nodePort: {{ .Values.collector.service.http.nodePort }}
+{{- end }}
     protocol: TCP
     targetPort: http
-{{- if .Values.collector.service.zipkinPort }}
+{{- if .Values.collector.service.zipkin }}
   - name: zipkin
-    port: {{ .Values.collector.service.zipkinPort }}
+    port: {{ .Values.collector.service.zipkin.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.zipkin.nodePort) }}
+    nodePort: {{ .Values.collector.service.zipkin.nodePort }}
+{{- end }}
     protocol: TCP
     targetPort: zipkin
 {{- end }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -149,7 +149,7 @@ spec:
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
-          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpcPort }}
+          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
         {{- range $key, $value := .Values.agent.cmdlineParams }}
         - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -216,13 +216,21 @@ collector:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
-    grpcPort: 14250
+    grpc:
+      port: 14250
+      # nodePort:
     # tchannelPort: used by jaeger-agent to send spans in jaeger.thrift format
-    tchannelPort: 14267
+    tchannel:
+      port: 14267
+      # nodePort:
     # httpPort: can accept spans directly from clients in jaeger.thrift format
-    httpPort: 14268
+    http:
+      port: 14268
+      # nodePort:
     # can accept Zipkin spans in JSON or Thrift
-    # zipkinPort: 9411
+    zipkin:
+      # port: 9411
+      # nodePort:
   resources: {}
     # limits:
     #   cpu: 1


### PR DESCRIPTION
Hello.
My installation has some services landed outside the k8s cluster. Manually set a nodePort number for collector is important to bring agent's config valid over time.