### PR TITLE
Add service accoiunt for es-index-cleaner object

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.22.0
+version: 0.22.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-index-cleaner-sa.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-sa.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.esIndexCleaner.enabled .Values.esIndexCleaner.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jaeger.esIndexCleaner.serviceAccountName" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-index-cleaner
+{{- end -}}


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

Chart version 0.22.0 has a bug:

If `.Values.esIndexCleaner.serviceAccount.create` is set to true to create a service account, the cleaner job fails to create a pod because no service account is created (as there is no template for the service account).