### PR TITLE
[jaeger] Added LoadBalancerIP in the Helm Chart

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.23.0
+version: 0.24.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.17.0
+appVersion: 1.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 version: 0.22.2

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -262,6 +262,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.service.annotations` | Annotations for Collector SVC | `nil` |
 | `collector.service.grpc.port` | Jaeger Agent port for model.proto | `14250` |
 | `collector.service.http.port` | Client port for HTTP thrift | `14268` |
+| `collector.service.loadBalancerIP` | IP Address to be assigned to the Load Balancer | `nil` |
 | `collector.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
 | `collector.service.tchannel.port` | Jaeger Agent port for thrift| `14267` |
 | `collector.service.type` | Service type | `ClusterIP` |

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -46,7 +46,7 @@ spec:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
-{{- if and (eq .Values.collector.service.type "loadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
+{{- if and (eq .Values.collector.service.type "LoadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
     LoadBalancerIP: {{ .Values.collector.service.type.loadBalancerIP }}
 {{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -46,7 +46,7 @@ spec:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
-{{- if and (eq .Values.collector.service.type "LoadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
+{{- if and (eq .Values.collector.service.type "LoadBalancer") .Values.collector.service.loadBalancerIP }}
     LoadBalancerIP: {{ .Values.collector.service.type.loadBalancerIP }}
 {{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -46,5 +46,8 @@ spec:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
+{{- if and (eq .Values.collector.service.type "LoadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
+    LoadBalancerIP: {{ .Values.collector.service.type.loadBalancerIP }}
+{{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}
 {{- end -}}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -47,7 +47,7 @@ spec:
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
 {{- if and (eq .Values.collector.service.type "LoadBalancer") .Values.collector.service.loadBalancerIP }}
-    LoadBalancerIP: {{ .Values.collector.service.type.loadBalancerIP }}
+    LoadBalancerIP: {{ .Values.collector.service.loadBalancerIP }}
 {{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}
 {{- end -}}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -46,7 +46,7 @@ spec:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
-{{- if and (eq .Values.collector.service.type "LoadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
+{{- if and (eq .Values.collector.service.type "loadBalancer") (.Values.collector.service.loadBalancerIPEnabled) }}
     LoadBalancerIP: {{ .Values.collector.service.type.loadBalancerIP }}
 {{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -47,7 +47,7 @@ spec:
     app.kubernetes.io/component: collector
   type: {{ .Values.collector.service.type }}
 {{- if and (eq .Values.collector.service.type "LoadBalancer") .Values.collector.service.loadBalancerIP }}
-    loadBalancerIP: {{ .Values.collector.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.collector.service.loadBalancerIP }}
 {{- end -}}    
 {{- template "loadBalancerSourceRanges" .Values.collector }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -214,6 +214,8 @@ collector:
   service:
     annotations: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)
+    loadBalancerIPEnabled: false
+    loadBalancerIP: ''
     loadBalancerSourceRanges: []
     type: ClusterIP
     grpc:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -213,9 +213,9 @@ collector:
     # targetMemoryUtilizationPercentage: 80
   service:
     annotations: {}
-    # List of IP ranges that are allowed to access the load balancer (if supported)
-    loadBalancerIPEnabled: false
+    # The IP to be used by the load balancer (if supported)
     loadBalancerIP: ''
+    # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
     grpc:


### PR DESCRIPTION
I noticed that there is no way to add a LoadBalancerIP to a Helm chart, if someone would want to deploy the Jaeger-collector service with the type Load Balancer. Hence, I have added an optional parameter for LoadBalancerIP that can be specified with the LoadBalancer Jaeger-collector service.