### PR TITLE
Add ES_TAGS_AS_FIELDS_ALL field to jaeger chart

### DIFF
--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -110,6 +110,10 @@ spec:
           - name: ES_INDEX_PREFIX
             value: {{ .Values.storage.elasticsearch.indexPrefix }}
           {{- end }}
+          {{- if .Values.storage.elasticsearch.tagsAsFieldsAll }}
+          - name: ES_TAGS_AS_FIELDS_ALL
+            value: {{ .Values.storage.elasticsearch.tagsAsFieldsAll }}
+          {{- end }}  
           {{- end }}
           {{- end }}
           {{- if .Values.collector.samplingConfig}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -35,6 +35,7 @@ storage:
     usePassword: true
     password: changeme
     # indexPrefix: test
+    # tagsAsFieldsAll: false
     ## Use existing secret (ignores previous password)
     # existingSecret:
     nodesWanOnly: false


### PR DESCRIPTION
This commit adds support for the  missing environment variable ES_TAGS_AS_FIELDS_ALL.

Fixes: https://github.com/jaegertracing/helm-charts/issues/70