### PR TITLE
refactor-config

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v1
 
       - name: Run chart-testing (lint)
         id: lint

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.22.2
+version: 0.23.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -226,6 +226,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `<agent|collector|query|ingester>.cmdlineParams` | Additional command line parameters | `nil` |
+| `<component>.env` | Additional environment variables | {} |
 | `<component>.nodeSelector` | Node selector | {} |
 | `<component>.tolerations` | Node tolerations | [] |
 | `<component.affinity` | Affinity | {} |
@@ -234,7 +236,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `<component>.serviceAccount.create` | Create service account | `true` |
 | `<component>.serviceAccount.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
 | `agent.annotations` | Annotations for Agent | `nil` |
-| `agent.cmdlineParams` |Additional command line parameters| `nil` |
 | `agent.dnsPolicy` | Configure DNS policy for agents | `ClusterFirst` |
 | `agent.service.annotations` | Annotations for Agent SVC | `nil` |
 | `agent.service.binaryPort` | jaeger.thrift over binary thrift | `6832` |
@@ -255,7 +256,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.autoscaling.maxReplicas` | Maximum replicas |  10 |
 | `collector.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization |  80 |
 | `collector.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `nil` |
-| `collector.cmdlineParams` | Additional command line parameters | `nil` |
 | `collector.podAnnotations` | Annotations for Collector pod | `nil` |
 | `collector.image` | Image for jaeger collector | `jaegertracing/jaeger-collector` |
 | `collector.pullPolicy` | Collector image pullPolicy | `IfNotPresent` |
@@ -275,7 +275,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `ingester.autoscaling.maxReplicas` | Maximum replicas |  10 |
 | `ingester.autoscaling.targetCPUUtilizationPercentage` | Target CPU utilization |  80 |
 | `ingester.autoscaling.targetMemoryUtilizationPercentage` | Target memory utilization | `nil` |
-| `ingester.cmdlineParams` | Additional command line parameters | `nil` |
 | `ingester.podAnnotations` | Annotations for Ingester pod | `nil` |
 | `ingester.service.annotations` | Annotations for Ingester SVC | `nil` |
 | `ingester.image` | Image for jaeger Ingester | `jaegertracing/jaeger-ingester` |
@@ -294,7 +293,6 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `provisionDataStore.kafka` | Provision Kafka Data Store | `false` |
 | `query.agentSidecar.enabled` | Enable agent sidecare for query deployment | `true` |
 | `query.service.annotations` | Annotations for Query SVC | `nil` |
-| `query.cmdlineParams` | Additional command line parameters | `nil` |
 | `query.image` | Image for Jaeger Query UI | `jaegertracing/jaeger-query` |
 | `query.ingress.enabled` | Allow external traffic access | `false` |
 | `query.ingress.annotations` | Configure annotations for Ingress | `{}` |
@@ -310,12 +308,13 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.annotations` | Annotations for the schema job| `nil` |
 | `schema.extraConfigmapMounts` | Additional cassandra schema job configMap mounts | `[]`  |
 | `schema.image` | Image to setup cassandra schema | `jaegertracing/jaeger-cassandra-schema` |
-| `schema.mode` | Schema mode (prod or test) | `prod` |
+| `schema.env` | Environment variables for cassandra-schema-job | `MODE: prod` |
+| `schema.mode` | (DEPRECATED, use `schema.env`) Schema mode (prod or test) | `prod` |
 | `schema.pullPolicy` | Schema image pullPolicy | `IfNotPresent` |
 | `schema.activeDeadlineSeconds` | Deadline in seconds for cassandra schema creation job to complete | `120` |
 | `schema.traceTtl` | Time to live for trace data in seconds | `nil` |
 | `schema.keyspace` | Set explicit keyspace name | `nil` |
-| `schema.dependenciesTtl` | Time to live for dependencies data in seconds | `nil` |
+| `schema.dependenciesTtl` | (DEPRECATED, use `schema.env`) Time to live for dependencies data in seconds | `nil` |
 | `spark.enabled` | Enables the dependencies job| `false` |
 | `spark.image` | Image for the dependencies job| `jaegertracing/spark-dependencies` |
 | `spark.pullPolicy` | Image pull policy of the deps image | `Always` |
@@ -335,6 +334,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `esIndexCleaner.tag` | Tag of the dependencies job image | `latest` |
 | `esIndexCleaner.extraConfigmapMounts` | Additional esIndexCleaner configMap mounts | `[]` |
 | `esIndexCleaner.extraSecretMounts` | Additional esIndexCleaner secret mounts | `[]` |
+| `storage.cassandra.env` | Extra cassandra related env vars to be configured on components that talk to cassandra | `cassandra` |
+| `storage.cassandra.cmdlineParams` | Extra cassandra related command line options to be configured on components that talk to cassandra | `cassandra` |
 | `storage.cassandra.existingSecret` | Name of existing password secret object (for password authentication | `nil`
 | `storage.cassandra.host` | Provisioned cassandra host | `cassandra` |
 | `storage.cassandra.keyspace` | Schema name for cassandra | `jaeger_v1_test` |
@@ -344,6 +345,8 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.cassandra.tls.secretName` | Provisioned cassandra TLS connection existing secret name (possible keys in secret: `ca-cert.pem`, `client-key.pem`, `client-cert.pem`, `cqlshrc`, `commonName`) | `` |
 | `storage.cassandra.usePassword` | Use password | `true` |
 | `storage.cassandra.user` | Provisioned cassandra username | `user` |
+| `storage.elasticsearch.env` | Extra ES related env vars to be configured on components that talk to ES | `nil` |
+| `storage.elasticsearch.cmdlineParams` | Extra ES related command line options to be configured on components that talk to ES | `nil` |
 | `storage.elasticsearch.existingSecret` | Name of existing password secret object (for password authentication | `nil` |
 | `storage.elasticsearch.host` | Provisioned elasticsearch host| `elasticsearch` |
 | `storage.elasticsearch.password` | Provisioned elasticsearch password  (ignored if storage.elasticsearch.existingSecret set | `changeme` |

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -326,13 +326,16 @@ Cassandra or Elasticsearch related environment variables depending on which is u
 {{- end -}}
 {{- end -}}
 
-
 {{/*
 Cassandra related command line options
 */}}
 {{- define "cassandra.cmdArgs" -}}
-{{- range $key, $value := .Values.storage.cassandra.cmdlineParams }}
+{{- range $key, $value := .Values.storage.cassandra.cmdlineParams -}}
+{{- if $value -}}
 - --{{ $key }}={{ $value }}
+{{- else }}
+- --{{ $key }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -340,8 +343,12 @@ Cassandra related command line options
 Elasticsearch related command line options
 */}}
 {{- define "elasticsearch.cmdArgs" -}}
-{{- range $key, $value := .Values.storage.elasticsearch.cmdlineParams }}
+{{- range $key, $value := .Values.storage.elasticsearch.cmdlineParams -}}
+{{- if $value -}}
 - --{{ $key }}={{ $value }}
+{{- else }}
+- --{{ $key }}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 
@@ -350,8 +357,8 @@ Cassandra or Elasticsearch related command line options depending on which is us
 */}}
 {{- define "storage.cmdArgs" -}}
 {{- if eq .Values.storage.type "cassandra" -}}
-{{ include "cassandra.cmdArgs" . }}
+{{- include "cassandra.cmdArgs" . -}}
 {{- else if eq .Values.storage.type "elasticsearch" -}}
-{{ include "elasticsearch.cmdArgs" . }}
+{{- include "elasticsearch.cmdArgs" . -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -56,9 +56,9 @@ Create the name of the cassandra schema service account to use
 */}}
 {{- define "jaeger.cassandraSchema.serviceAccountName" -}}
 {{- if .Values.schema.serviceAccount.create -}}
-    {{ default (printf "%s-cassandra-schema" (include "jaeger.fullname" .)) .Values.schema.serviceAccount.name }}
+  {{ default (printf "%s-cassandra-schema" (include "jaeger.fullname" .)) .Values.schema.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.schema.serviceAccount.name }}
+  {{ default "default" .Values.schema.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -67,9 +67,9 @@ Create the name of the spark service account to use
 */}}
 {{- define "jaeger.spark.serviceAccountName" -}}
 {{- if .Values.spark.serviceAccount.create -}}
-    {{ default (printf "%s-spark" (include "jaeger.fullname" .)) .Values.spark.serviceAccount.name }}
+  {{ default (printf "%s-spark" (include "jaeger.fullname" .)) .Values.spark.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.spark.serviceAccount.name }}
+  {{ default "default" .Values.spark.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -78,9 +78,9 @@ Create the name of the esIndexCleaner service account to use
 */}}
 {{- define "jaeger.esIndexCleaner.serviceAccountName" -}}
 {{- if .Values.esIndexCleaner.serviceAccount.create -}}
-    {{ default (printf "%s-es-index-cleaner" (include "jaeger.fullname" .)) .Values.esIndexCleaner.serviceAccount.name }}
+  {{ default (printf "%s-es-index-cleaner" (include "jaeger.fullname" .)) .Values.esIndexCleaner.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.esIndexCleaner.serviceAccount.name }}
+  {{ default "default" .Values.esIndexCleaner.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -89,9 +89,9 @@ Create the name of the hotrod service account to use
 */}}
 {{- define "jaeger.hotrod.serviceAccountName" -}}
 {{- if .Values.hotrod.serviceAccount.create -}}
-    {{ default (printf "%s-hotrod" (include "jaeger.fullname" .)) .Values.hotrod.serviceAccount.name }}
+  {{ default (printf "%s-hotrod" (include "jaeger.fullname" .)) .Values.hotrod.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.hotrod.serviceAccount.name }}
+  {{ default "default" .Values.hotrod.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -100,9 +100,9 @@ Create the name of the query service account to use
 */}}
 {{- define "jaeger.query.serviceAccountName" -}}
 {{- if .Values.query.serviceAccount.create -}}
-    {{ default (include "jaeger.query.name" .) .Values.query.serviceAccount.name }}
+  {{ default (include "jaeger.query.name" .) .Values.query.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.query.serviceAccount.name }}
+  {{ default "default" .Values.query.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -111,9 +111,9 @@ Create the name of the agent service account to use
 */}}
 {{- define "jaeger.agent.serviceAccountName" -}}
 {{- if .Values.agent.serviceAccount.create -}}
-    {{ default (include "jaeger.agent.name" .) .Values.agent.serviceAccount.name }}
+  {{ default (include "jaeger.agent.name" .) .Values.agent.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.agent.serviceAccount.name }}
+  {{ default "default" .Values.agent.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -122,9 +122,9 @@ Create the name of the collector service account to use
 */}}
 {{- define "jaeger.collector.serviceAccountName" -}}
 {{- if .Values.collector.serviceAccount.create -}}
-    {{ default (include "jaeger.collector.name" .) .Values.collector.serviceAccount.name }}
+  {{ default (include "jaeger.collector.name" .) .Values.collector.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.collector.serviceAccount.name }}
+  {{ default "default" .Values.collector.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -133,9 +133,9 @@ Create the name of the ingester service account to use
 */}}
 {{- define "jaeger.ingester.serviceAccountName" -}}
 {{- if .Values.ingester.serviceAccount.create -}}
-    {{ default (include "jaeger.ingester.name" .) .Values.ingester.serviceAccount.name }}
+  {{ default (include "jaeger.ingester.name" .) .Values.ingester.serviceAccount.name }}
 {{- else -}}
-    {{ default "default" .Values.ingester.serviceAccount.name }}
+  {{ default "default" .Values.ingester.serviceAccount.name }}
 {{- end -}}
 {{- end -}}
 
@@ -247,4 +247,111 @@ Configure list of IP CIDRs allowed access to load balancer (if supported)
 {{- define "helm-toolkit.utils.joinListWithComma" -}}
 {{- $local := dict "first" true -}}
 {{- range $k, $v := . -}}{{- if not $local.first -}},{{- end -}}{{- $v -}}{{- $_ := set $local "first" false -}}{{- end -}}
+{{- end -}}
+
+
+{{/*
+Cassandra related environment variables
+*/}}
+{{- define "cassandra.env" -}}
+- name: CASSANDRA_SERVERS
+  value: {{ include "cassandra.host" . }}
+- name: CASSANDRA_PORT
+  value: {{ .Values.storage.cassandra.port | quote }}
+{{ if .Values.storage.cassandra.tls.enabled }}
+- name: CASSANDRA_TLS_ENABLED
+  value: "true"
+- name: CASSANDRA_TLS_SERVER_NAME
+  valueFrom:
+    secretKeyRef:
+      name: {{ .Values.storage.cassandra.tls.secretName }}
+      key: commonName
+- name: CASSANDRA_TLS_KEY
+  value: "/cassandra-tls/client-key.pem"
+- name: CASSANDRA_TLS_CERT
+  value: "/cassandra-tls/client-cert.pem"
+- name: CASSANDRA_TLS_CA
+  value: "/cassandra-tls/ca-cert.pem"
+{{- end }}
+{{- if .Values.storage.cassandra.keyspace }}
+- name: CASSANDRA_KEYSPACE
+  value: {{ .Values.storage.cassandra.keyspace }}
+{{- end }}
+- name: CASSANDRA_USERNAME
+  value: {{ .Values.storage.cassandra.user }}
+- name: CASSANDRA_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
+      key: password
+{{- range $key, $value := .Values.storage.cassandra.env -}}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Elasticsearch related environment variables
+*/}}
+{{- define "elasticsearch.env" -}}
+- name: ES_SERVER_URLS
+  value: {{ include "elasticsearch.client.url" . }}
+- name: ES_USERNAME
+  value: {{ .Values.storage.elasticsearch.user }}
+{{- if .Values.storage.elasticsearch.usePassword }}
+- name: ES_PASSWORD
+  valueFrom:
+    secretKeyRef:
+      name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
+      key: password
+{{- end }}
+{{- if .Values.storage.elasticsearch.indexPrefix }}
+- name: ES_INDEX_PREFIX
+  value: {{ .Values.storage.elasticsearch.indexPrefix }}
+{{- end }}
+{{- range $key, $value := .Values.storage.elasticsearch.env -}}
+- name: {{ $key | quote }}
+  value: {{ $value | quote }}
+{{ end -}}
+{{- end -}}
+
+{{/*
+Cassandra or Elasticsearch related environment variables depending on which is used
+*/}}
+{{- define "storage.env" -}}
+{{- if eq .Values.storage.type "cassandra" -}}
+{{ include "cassandra.env" . }}
+{{- else if eq .Values.storage.type "elasticsearch" -}}
+{{ include "elasticsearch.env" . }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Cassandra related command line options
+*/}}
+{{- define "cassandra.cmdArgs" -}}
+{{- range $key, $value := .Values.storage.cassandra.cmdlineParams }}
+- --{{ $key }}={{ $value }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Elasticsearch related command line options
+*/}}
+{{- define "elasticsearch.cmdArgs" -}}
+{{- range $key, $value := .Values.storage.elasticsearch.cmdlineParams }}
+- --{{ $key }}={{ $value }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Cassandra or Elasticsearch related command line options depending on which is used
+*/}}
+{{- define "storage.cmdArgs" -}}
+{{- if eq .Values.storage.type "cassandra" -}}
+{{ include "cassandra.cmdArgs" . }}
+{{- else if eq .Values.storage.type "elasticsearch" -}}
+{{ include "elasticsearch.cmdArgs" . }}
+{{- end -}}
 {{- end -}}

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -43,7 +43,11 @@ spec:
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:
           {{- range $key, $value := .Values.agent.cmdlineParams }}
+          {{- if $value }}
           - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
           {{- end }}
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -41,14 +41,14 @@ spec:
 {{ toYaml .Values.agent.securityContext | indent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
+        args:
+          {{- range $key, $value := .Values.agent.cmdlineParams }}
+          - --{{ $key }}={{ $value }}
+          {{- end }}
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
           value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
-        {{- end }}
-        {{- range $key, $value := .Values.agent.cmdlineParams }}
-        - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-          value: {{ $value | quote }}
         {{- end }}
         ports:
         - name: zipkin-compact

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -27,6 +27,11 @@ spec:
         image: {{ .Values.schema.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
+        {{ range $key, $value := .Values.schema.env }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{ end }}
+        {{- include "cassandra.env" . | nindent 8 }}
         - name: CQLSH_HOST
           value: {{ template "cassandra.host" . }}
         {{ if .Values.storage.cassandra.tls.enabled }}
@@ -37,19 +42,6 @@ spec:
           value: {{ .Values.schema.mode | quote }}
         - name: DATACENTER
           value: {{ .Values.cassandra.config.dc_name | quote }}
-        - name: CASSANDRA_PORT
-          value: {{ .Values.storage.cassandra.port | quote }}
-        - name: CASSANDRA_USERNAME
-          value: {{ .Values.storage.cassandra.user }}
-        - name: CASSANDRA_PASSWORD
-          valueFrom:
-            secretKeyRef:
-              name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
-              key: password
-      {{- if .Values.storage.cassandra.keyspace }}
-        - name: KEYSPACE
-          value: {{ .Values.storage.cassandra.keyspace | quote }}
-      {{- end }}
       {{- if .Values.schema.traceTtl }}
         - name: TRACE_TTL
           value: {{ .Values.schema.traceTtl | quote }}
@@ -57,6 +49,10 @@ spec:
       {{- if .Values.schema.dependenciesTtl }}
         - name: DEPENDENCIES_TTL
           value: {{ .Values.schema.dependenciesTtl | quote }}
+      {{- end }}
+      {{- if .Values.storage.cassandra.keyspace }}
+        - name: KEYSPACE
+          value: {{ .Values.storage.cassandra.keyspace }}
       {{- end }}
         resources:
 {{ toYaml .Values.schema.resources | indent 10 }}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -45,7 +45,11 @@ spec:
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         args:
           {{- range $key, $value := .Values.collector.cmdlineParams -}}
+          {{- if $value }}
           - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
           {{- end -}}
           {{- if not .Values.ingester.enabled -}}
           {{- include "storage.cmdArgs" . | nindent 10 }}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -43,11 +43,14 @@ spec:
 {{ toYaml .Values.collector.securityContext | indent 10 }}
         image: {{ .Values.collector.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
-        env:
-          {{- range $key, $value := .Values.collector.cmdlineParams }}
-          - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-            value: {{ $value | quote }}
+        args:
+          {{- range $key, $value := .Values.collector.cmdlineParams -}}
+          - --{{ $key }}={{ $value }}
+          {{- end -}}
+          {{- if not .Values.ingester.enabled -}}
+          {{- include "storage.cmdArgs" . | nindent 10 }}
           {{- end }}
+        env:
           {{- if .Values.collector.service.zipkin }}
           - name: COLLECTOR_ZIPKIN_HTTP_PORT
             value: {{ .Values.collector.service.zipkin.port | quote }}
@@ -55,6 +58,10 @@ spec:
           {{- if .Values.ingester.enabled }}
           - name: SPAN_STORAGE_TYPE
             value: kafka
+          {{- range $key, $value := .Values.storage.kafka.env }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
           - name: KAFKA_PRODUCER_BROKERS
             value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers }}
           - name: KAFKA_PRODUCER_TOPIC
@@ -62,55 +69,7 @@ spec:
           {{ else }}
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
-          {{- if eq .Values.storage.type "cassandra" }}
-          - name: CASSANDRA_SERVERS
-            value: {{ template "cassandra.host" . }}
-          - name: CASSANDRA_PORT
-            value: {{ .Values.storage.cassandra.port | quote }}
-          {{ if .Values.storage.cassandra.tls.enabled }}
-          - name: CASSANDRA_TLS
-            value: "true"
-          - name: CASSANDRA_TLS_SERVER_NAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.storage.cassandra.tls.secretName }}
-                key: commonName
-          - name: CASSANDRA_TLS_KEY
-            value: "/cassandra-tls/client-key.pem"
-          - name: CASSANDRA_TLS_CERT
-            value: "/cassandra-tls/client-cert.pem"
-          - name: CASSANDRA_TLS_CA
-            value: "/cassandra-tls/ca-cert.pem"
-          {{- end }}
-          {{- if .Values.storage.cassandra.keyspace }}
-          - name: CASSANDRA_KEYSPACE
-            value: {{ .Values.storage.cassandra.keyspace }}
-          {{- end }}
-          - name: CASSANDRA_USERNAME
-            value: {{ .Values.storage.cassandra.user }}
-          - name: CASSANDRA_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
-                key: password
-          {{- end }}
-          {{- if eq .Values.storage.type "elasticsearch" }}
-          {{- if .Values.storage.elasticsearch.usePassword }}
-          - name: ES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
-                key: password
-          {{- end }}
-          - name: ES_SERVER_URLS
-            value: {{ template "elasticsearch.client.url" . }}
-          - name: ES_USERNAME
-            value: {{ .Values.storage.elasticsearch.user }}
-          {{- if .Values.storage.elasticsearch.indexPrefix }}
-          - name: ES_INDEX_PREFIX
-            value: {{ .Values.storage.elasticsearch.indexPrefix }}
-          {{- end }}
-          {{- end }}
+          {{- include "storage.env" . | nindent 10 }}
           {{- end }}
           {{- if .Values.collector.samplingConfig}}
           - name: SAMPLING_STRATEGIES_FILE

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -38,7 +38,13 @@ spec:
             imagePullPolicy: {{ .Values.esIndexCleaner.pullPolicy }}
             args:
             - {{ .Values.esIndexCleaner.numberOfDays | quote }}
-            - {{ template "elasticsearch.client.url" . }}
+            - {{ include "elasticsearch.client.url" . }}
+            env:
+              {{- range $key, $value := .Values.esIndexCleaner.env }}
+              - name: {{ $key | quote }}
+                value: {{ $value | quote }}
+              {{- end }}
+              {{ include "elasticsearch.env" . | nindent 14 }}
             resources:
 {{ toYaml .Values.esIndexCleaner.resources | indent 14 }}
             volumeMounts:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -47,64 +47,19 @@ spec:
 {{ toYaml .Values.ingester.securityContext | indent 10 }}
         image: {{ .Values.ingester.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
-        env:
+        args:
           {{- range $key, $value := .Values.ingester.cmdlineParams }}
-          - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-            value: {{ $value | quote }}
+          - --{{ $key }}={{ $value }}
           {{- end }}
+          {{- include "storage.cmdArgs" . | nindent 10 }}
+        env:
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
+          {{- include "storage.env" . | nindent 10 }}
           - name: KAFKA_CONSUMER_BROKERS
             value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers }}
           - name: KAFKA_CONSUMER_TOPIC
             value: {{ .Values.storage.kafka.topic }}
-          {{- if eq .Values.storage.type "cassandra" }}
-          - name: CASSANDRA_SERVERS
-            value: {{ .Values.storage.cassandra.host | quote }}
-          - name: CASSANDRA_PORT
-            value: {{ .Values.storage.cassandra.port | quote }}
-          {{ if .Values.storage.cassandra.tls.enabled }}
-          - name: CASSANDRA_TLS
-            value: "true"
-          - name: CASSANDRA_TLS_SERVER_NAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.storage.cassandra.tls.secretName }}
-                key: commonName
-          - name: CASSANDRA_TLS_KEY
-            value: "/cassandra-tls/client-key.pem"
-          - name: CASSANDRA_TLS_CERT
-            value: "/cassandra-tls/client-cert.pem"
-          - name: CASSANDRA_TLS_CA
-            value: "/cassandra-tls/ca-cert.pem"
-          {{- end }}
-          - name: CASSANDRA_KEYSPACE
-            value: {{ .Values.storage.cassandra.keyspace | quote }}
-          - name: CASSANDRA_USERNAME
-            value: {{ .Values.storage.cassandra.user }}
-          - name: CASSANDRA_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
-                key: password
-          {{- end }}
-          {{- if eq .Values.storage.type "elasticsearch" }}
-          {{- if .Values.storage.elasticsearch.usePassword }}
-          - name: ES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
-                key: password
-          {{- end }}
-          - name: ES_SERVER_URLS
-            value: {{ template "elasticsearch.client.url" . }}
-          - name: ES_USERNAME
-            value: {{ .Values.storage.elasticsearch.user }}
-          {{- if .Values.storage.elasticsearch.indexPrefix }}
-          - name: ES_INDEX_PREFIX
-            value: {{ .Values.storage.elasticsearch.indexPrefix }}
-          {{- end }}
-          {{- end }}
         ports:
         - containerPort: 14270
           name: admin

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -49,7 +49,11 @@ spec:
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
         args:
           {{- range $key, $value := .Values.ingester.cmdlineParams }}
+          {{- if $value }}
           - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
           {{- end }}
           {{- include "storage.cmdArgs" . | nindent 10 }}
         env:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -40,62 +40,15 @@ spec:
 {{ toYaml .Values.query.securityContext | indent 10 }}
         image: {{ .Values.query.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
-        env:
+        args:
           {{- range $key, $value := .Values.query.cmdlineParams }}
-          - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-            value: {{ $value | quote }}
+          - --{{ $key }}={{ $value }}
           {{- end }}
+          {{- include "storage.cmdArgs" . | nindent 10 }}
+        env:
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
-          {{- if eq .Values.storage.type "cassandra" }}
-          - name: CASSANDRA_SERVERS
-            value: {{ template "cassandra.host" . }}
-          - name: CASSANDRA_PORT
-            value: {{ .Values.storage.cassandra.port | quote }}
-          {{ if .Values.storage.cassandra.tls.enabled }}
-          - name: CASSANDRA_TLS
-            value: "true"
-          - name: CASSANDRA_TLS_SERVER_NAME
-            valueFrom:
-              secretKeyRef:
-                name: {{ .Values.storage.cassandra.tls.secretName }}
-                key: commonName
-          - name: CASSANDRA_TLS_KEY
-            value: "/cassandra-tls/client-key.pem"
-          - name: CASSANDRA_TLS_CERT
-            value: "/cassandra-tls/client-cert.pem"
-          - name: CASSANDRA_TLS_CA
-            value: "/cassandra-tls/ca-cert.pem"
-          {{- end }}
-          {{- if .Values.storage.cassandra.keyspace }}
-          - name: CASSANDRA_KEYSPACE
-            value: {{ .Values.storage.cassandra.keyspace | quote }}
-          {{- end }}
-          - name: CASSANDRA_USERNAME
-            value: {{ .Values.storage.cassandra.user }}
-          - name: CASSANDRA_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
-                key: password
-          {{- end }}
-          {{- if eq .Values.storage.type "elasticsearch" }}
-          {{- if .Values.storage.elasticsearch.usePassword }}
-          - name: ES_PASSWORD
-            valueFrom:
-              secretKeyRef:
-                name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
-                key: password
-          {{- end }}
-          - name: ES_SERVER_URLS
-            value: {{ template "elasticsearch.client.url" . }}
-          - name: ES_USERNAME
-            value: {{ .Values.storage.elasticsearch.user }}
-          {{- if .Values.storage.elasticsearch.indexPrefix }}
-          - name: ES_INDEX_PREFIX
-            value: {{ .Values.storage.elasticsearch.indexPrefix }}
-          {{- end }}
-          {{- end }}
+          {{- include "storage.env" . | nindent 10 }}
           {{- if .Values.query.basePath }}
           - name: QUERY_BASE_PATH
             value: {{ .Values.query.basePath | quote }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -42,7 +42,11 @@ spec:
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         args:
           {{- range $key, $value := .Values.query.cmdlineParams }}
+          {{- if $value }}
           - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
           {{- end }}
           {{- include "storage.cmdArgs" . | nindent 10 }}
         env:
@@ -105,14 +109,18 @@ spec:
 {{ toYaml .Values.query.securityContext | indent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
+        args:
+          {{- range $key, $value := .Values.agent.cmdlineParams }}
+          {{- if $value }}
+          - --{{ $key }}={{ $value }}
+          {{- else }}
+          - --{{ $key }}
+          {{- end }}
+          {{- end }}
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
           value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
-        {{- end }}
-        {{- range $key, $value := .Values.agent.cmdlineParams }}
-        - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-          value: {{ $value | quote }}
         {{- end }}
         ports:
         - name: admin

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -32,7 +32,11 @@ spec:
             imagePullPolicy: {{ .Values.spark.pullPolicy }}
             args:
               {{- range $key, $value := .Values.spark.cmdlineParams }}
+              {{- if $value }}
               - --{{ $key }}={{ $value }}
+              {{- else }}
+              - --{{ $key }}
+              {{- end }}
               {{- end }}
             env:
               - name: STORAGE

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -30,43 +30,20 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-spark
             image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}
             imagePullPolicy: {{ .Values.spark.pullPolicy }}
+            args:
+              {{- range $key, $value := .Values.spark.cmdlineParams }}
+              - --{{ $key }}={{ $value }}
+              {{- end }}
             env:
-            {{- range $key, $value := .Values.spark.cmdlineParams }}
-            - name: {{ $key | replace "." "_" | replace "-" "_" | upper | quote }}
-              value: {{ $value | quote }}
-            {{- end }}
-            - name: STORAGE
-              value: {{ .Values.storage.type }}
-            {{- if eq .Values.storage.type "cassandra" }}
-            - name: CASSANDRA_CONTACT_POINTS
-              value: {{ template "cassandra.contact_points" . }}
-            - name: CASSANDRA_KEYSPACE
-              value: {{ .Values.storage.cassandra.keyspace }}
-            {{- if .Values.storage.cassandra.usePassword }}
-            - name: CASSANDRA_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
-                  key: password
-            {{- end }}
-            - name: CASSANDRA_USERNAME
-              value: {{ .Values.storage.cassandra.user }}
-            {{- end }}
-            {{- if eq .Values.storage.type "elasticsearch" }}
-            - name: ES_NODES
-              value: {{ template "elasticsearch.client.url" . }}
-            - name: ES_NODES_WAN_ONLY
-              value: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
-            {{- if .Values.storage.elasticsearch.usePassword }}
-            - name: ES_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
-                  key: password
-            {{- end }}
-            - name: ES_USERNAME
-              value: {{ .Values.storage.elasticsearch.user }}
-            {{- end }}
+              - name: STORAGE
+                value: {{ .Values.storage.type }}
+              {{- include "storage.env" . | nindent 14 }}
+              - name: CASSANDRA_CONTACT_POINTS
+                value: {{ include "cassandra.contact_points" . }}
+              - name: ES_NODES
+                value: {{ include "elasticsearch.client.url" . }}
+              - name: ES_NODES_WAN_ONLY
+                value: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
             resources:
 {{ toYaml .Values.spark.resources | indent 14 }}
             volumeMounts:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -27,6 +27,18 @@ storage:
     keyspace: jaeger_v1_test
     ## Use existing secret (ignores previous password)
     # existingSecret:
+    ## Cassandra related env vars to be configured on the concerned components
+    env: {}
+      # CASSANDRA_SERVERS: cassandra
+      # CASSANDRA_PORT: 9042
+      # CASSANDRA_KEYSPACE: jaeger_v1_test
+      # CASSANDRA_TLS_ENABLED: false
+    ## Cassandra related cmd line opts to be configured on the concerned components
+    cmdlineParams: {}
+      # cassandra.servers: cassandra
+      # cassandra.port: 9042
+      # cassandra.keyspace: jaeger_v1_test
+      # cassandra.tls.enabled: false
   elasticsearch:
     scheme: http
     host: elasticsearch-master
@@ -38,6 +50,16 @@ storage:
     ## Use existing secret (ignores previous password)
     # existingSecret:
     nodesWanOnly: false
+    env: {}
+    ## ES related env vars to be configured on the concerned components
+      # ES_SERVER_URLS: http://elasticsearch-master:9200
+      # ES_USERNAME: elastic
+      # ES_INDEX_PREFIX: test
+    ## ES related cmd line opts to be configured on the concerned components
+    cmdlineParams: {}
+      # es.server-urls: http://elasticsearch-master:9200
+      # es.username: elastic
+      # es.index-prefix: test
   kafka:
     brokers:
       - kafka:9092
@@ -75,8 +97,9 @@ schema:
   annotations: {}
   image: jaegertracing/jaeger-cassandra-schema
   pullPolicy: IfNotPresent
-  # Acceptable values are test and prod. Default is for production use.
-  mode: prod
+  ## Acceptable values are test and prod. Default is for production use.
+  ## DEPRECATED, please use env further below
+  # mode: prod
   resources: {}
     # limits:
     #   cpu: 500m
@@ -92,8 +115,12 @@ schema:
   podLabels: {}
   ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 300
-  # traceTtl: 172800
-  # dependenciesTtl: 0
+  # traceTtl: 172800 <- DEPRECATED, please use env below
+  # dependenciesTtl: 0 <-DEPRECATED, please use env below
+  env:
+    MODE: prod
+    # TRACE_TTL: 172800
+    # DEPENDENCIES_TTL: 0
 
 # For configurable values of the elasticsearch if provisioned, please see:
 # https://github.com/elastic/helm-charts/tree/master/elasticsearch#configuration
@@ -108,6 +135,7 @@ ingester:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
+  env: {}
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -148,6 +176,7 @@ agent:
   image: jaegertracing/jaeger-agent
   pullPolicy: IfNotPresent
   cmdlineParams: {}
+  env: {}
   daemonset:
     useHostPort: false
   service:
@@ -204,6 +233,7 @@ collector:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
+  env: {}
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -303,6 +333,7 @@ query:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
+  env: {}
   replicaCount: 1
   service:
     annotations: {}


### PR DESCRIPTION
* cmd line options are templated as command arguments as they should be.
* components now have an env value to configure any env vars.
* Cassandra/Elasticsearch values that are required in the various components that talk to them (collector/ingester, query, spark-job, cassandra-schema, es-index-cleaner, however the latter three have non-standard env var names that are kept) have been moved to _helpers.tpl for shareability.

