### PR TITLE
[jaeger]Use nindent over indent

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -7,9 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
+        uses: actions/checkout@v1
 
       - name: Run chart-testing (lint)
         id: lint

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,9 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
-        with:
-          fetch-depth: "0"
+        uses: actions/checkout@v1
 
       - name: Configure Git
         run: |

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.23.2
+version: 0.23.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: agent
 {{- if .Values.agent.annotations }}
   annotations:
-{{ toYaml .Values.agent.annotations | indent 4 }}
+    {{- toYaml .Values.agent.annotations | nindent 4 }}
 {{- end }}
 spec:
   selector:
@@ -19,17 +19,17 @@ spec:
     metadata:
 {{- if .Values.agent.podAnnotations }}
       annotations:
-{{ toYaml .Values.agent.podAnnotations | indent 8 }}
+        {{- toYaml .Values.agent.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: agent
 {{- if .Values.agent.podLabels }}
-{{ toYaml .Values.agent.podLabels | indent 8 }}
+        {{- toYaml .Values.agent.podLabels | nindent 8 }}
 {{- end }}
     spec:
       securityContext:
-{{ toYaml .Values.agent.podSecurityContext | indent 8 }}
+        {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
       {{- if .Values.agent.useHostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -38,7 +38,7 @@ spec:
       containers:
       - name: {{ template "jaeger.agent.name" . }}
         securityContext:
-{{ toYaml .Values.agent.securityContext | indent 10 }}
+          {{- toYaml .Values.agent.securityContext | nindent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:
@@ -91,7 +91,7 @@ spec:
             path: /
             port: admin
         resources:
-{{ toYaml .Values.agent.resources | indent 10 }}
+          {{- toYaml .Values.agent.resources | nindent 10 }}
         volumeMounts:
         {{- range .Values.agent.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/templates/agent-svc.yaml
+++ b/charts/jaeger/templates/agent-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: agent
 {{- if .Values.agent.service.annotations }}
   annotations:
-{{ toYaml .Values.agent.service.annotations | indent 4 }}
+    {{- toYaml .Values.agent.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/component: cassandra-schema
 {{- if .Values.schema.annotations }}
   annotations:
-{{ toYaml .Values.schema.annotations | indent 4 }}
+    {{- toYaml .Values.schema.annotations | nindent 4 }}
 {{- end }}
 spec:
   activeDeadlineSeconds: {{ .Values.schema.activeDeadlineSeconds }}
@@ -18,7 +18,7 @@ spec:
       name: {{ include "jaeger.fullname" . }}-cassandra-schema
 {{- if .Values.schema.podLabels }}
       labels:
-{{ toYaml .Values.schema.podLabels | indent 8 }}
+        {{- toYaml .Values.schema.podLabels | nindent 8 }}
 {{- end }}
     spec:
       serviceAccountName: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
@@ -55,7 +55,7 @@ spec:
           value: {{ .Values.storage.cassandra.keyspace }}
       {{- end }}
         resources:
-{{ toYaml .Values.schema.resources | indent 10 }}
+          {{- toYaml .Values.schema.resources | nindent 10 }}
         volumeMounts:
         {{- range .Values.schema.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: collector
 {{- if .Values.collector.annotations }}
   annotations:
-{{ toYaml .Values.collector.annotations | indent 4 }}
+    {{- toYaml .Values.collector.annotations | nindent 4 }}
 {{- end }}
 spec:
 {{- if not .Values.collector.autoscaling.enabled }}
@@ -25,22 +25,22 @@ spec:
       annotations:
         checksum/config-env: {{ include (print $.Template.BasePath "/collector-configmap.yaml") . | sha256sum }}
 {{- if .Values.collector.podAnnotations }}
-{{ toYaml .Values.collector.podAnnotations | indent 8 }}
+        {{- toYaml .Values.collector.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: collector
 {{- if .Values.collector.podLabels }}
-{{ toYaml .Values.collector.podLabels | indent 8 }}
+        {{- toYaml .Values.collector.podLabels | nindent 8 }}
 {{- end }}
     spec:
       securityContext:
-{{ toYaml .Values.collector.podSecurityContext | indent 8 }}
+        {{- toYaml .Values.collector.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
         securityContext:
-{{ toYaml .Values.collector.securityContext | indent 10 }}
+          {{- toYaml .Values.collector.securityContext | nindent 10 }}
         image: {{ .Values.collector.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         args:
@@ -108,7 +108,7 @@ spec:
             path: /
             port: admin
         resources:
-{{ toYaml .Values.collector.resources | indent 10 }}
+          {{- toYaml .Values.collector.resources | nindent 10 }}
         volumeMounts:
         {{- range .Values.collector.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: collector
 {{- if .Values.collector.service.annotations }}
   annotations:
-{{ toYaml .Values.collector.service.annotations | indent 4 }}
+    {{- toYaml .Values.collector.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: es-index-cleaner
 {{- if .Values.esIndexCleaner.annotations }}
   annotations:
-{{ toYaml .Values.esIndexCleaner.annotations | indent 4 }}
+    {{- toYaml .Values.esIndexCleaner.annotations | nindent 4 }}
 {{- end }}
 spec:
   concurrencyPolicy: "Forbid"
@@ -24,16 +24,16 @@ spec:
             {{- include "jaeger.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: es-index-cleaner
             {{- if .Values.esIndexCleaner.podLabels }}
-{{ toYaml .Values.esIndexCleaner.podLabels | indent 12 }}
+            {{- toYaml .Values.esIndexCleaner.podLabels | nindent 12 }}
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esIndexCleaner.serviceAccountName" . }}
           securityContext:
-{{ toYaml .Values.esIndexCleaner.podSecurityContext | indent 12 }}
+            {{- toYaml .Values.esIndexCleaner.podSecurityContext | nindent 12 }}
           containers:
           - name: {{ include "jaeger.fullname" . }}-es-index-cleaner
             securityContext:
-{{ toYaml .Values.esIndexCleaner.securityContext | indent 14 }}
+              {{- toYaml .Values.esIndexCleaner.securityContext | nindent 14 }}
             image: "{{ .Values.esIndexCleaner.image }}:{{ .Values.esIndexCleaner.tag }}"
             imagePullPolicy: {{ .Values.esIndexCleaner.pullPolicy }}
             args:
@@ -46,7 +46,7 @@ spec:
               {{- end }}
               {{ include "elasticsearch.env" . | nindent 14 }}
             resources:
-{{ toYaml .Values.esIndexCleaner.resources | indent 14 }}
+              {{- toYaml .Values.esIndexCleaner.resources | nindent 14 }}
             volumeMounts:
             {{- range .Values.esIndexCleaner.extraConfigmapMounts }}
               - name: {{ .name }}

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -19,12 +19,12 @@ spec:
         app.kubernetes.io/component: hotrod
     spec:
       securityContext:
-{{ toYaml .Values.hotrod.podSecurityContext | indent 8 }}
+        {{- toYaml .Values.hotrod.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.hotrod.serviceAccountName" . }}
       containers:
         - name: {{ include "jaeger.fullname" . }}-hotrod
           securityContext:
-{{ toYaml .Values.hotrod.securityContext | indent 12 }}
+            {{- toYaml .Values.hotrod.securityContext | nindent 12 }}
           image: {{ .Values.hotrod.image.repository }}:{{ .Values.tag }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
           env:
@@ -45,7 +45,7 @@ spec:
               path: /
               port: http
           resources:
-{{ toYaml .Values.hotrod.resources | indent 12 }}
+            {{- toYaml .Values.hotrod.resources | nindent 12 }}
     {{- with .Values.hotrod.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -11,7 +11,7 @@ metadata:
     app.kubernetes.io/component: hotrod
 {{- if .Values.hotrod.ingress.annotations }}
   annotations:
-{{ toYaml .Values.hotrod.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
 {{- end }}
 spec:
   rules:
@@ -26,7 +26,7 @@ spec:
     {{- end -}}
   {{- if .Values.hotrod.ingress.tls }}
   tls:
-{{ toYaml .Values.hotrod.ingress.tls | indent 4 }}
+    {{- toYaml .Values.hotrod.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jaeger/templates/hotrod-svc.yaml
+++ b/charts/jaeger/templates/hotrod-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: hotrod
 {{- if .Values.hotrod.service.annotations }}
   annotations:
-{{ toYaml .Values.hotrod.service.annotations | indent 4 }}
+    {{- toYaml .Values.hotrod.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   type: {{ .Values.hotrod.service.type }}

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: ingester
 {{- if .Values.ingester.annotations }}
   annotations:
-{{ toYaml .Values.ingester.annotations | indent 4 }}
+    {{- toYaml .Values.ingester.annotations | nindent 4 }}
 {{- end }}
 spec:
 {{- if not .Values.ingester.autoscaling.enabled }}
@@ -24,27 +24,27 @@ spec:
     metadata:
       annotations:
 {{- if .Values.ingester.podAnnotations }}
-{{ toYaml .Values.ingester.podAnnotations | indent 8 }}
+        {{- toYaml .Values.ingester.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: ingester
 {{- if .Values.ingester.podLabels }}
-{{ toYaml .Values.ingester.podLabels | indent 8 }}
+        {{- toYaml .Values.ingester.podLabels | nindent 8 }}
 {{- end }}
     spec:
       securityContext:
-{{ toYaml .Values.ingester.podSecurityContext | indent 8 }}
+        {{- toYaml .Values.ingester.podSecurityContext | nindent 8 }}
       nodeSelector:
-{{ toYaml .Values.ingester.nodeSelector | indent 8 }}
+        {{- toYaml .Values.ingester.nodeSelector | nindent 8 }}
 {{- if .Values.ingester.tolerations }}
       tolerations:
-{{ toYaml .Values.ingester.tolerations | indent 8 }}
+        {{- toYaml .Values.ingester.tolerations | nindent 8 }}
 {{- end }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-ingester
         securityContext:
-{{ toYaml .Values.ingester.securityContext | indent 10 }}
+          {{- toYaml .Values.ingester.securityContext | nindent 10 }}
         image: {{ .Values.ingester.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
         args:
@@ -79,7 +79,7 @@ spec:
             path: /
             port: admin
         resources:
-{{ toYaml .Values.ingester.resources | indent 10 }}
+          {{- toYaml .Values.ingester.resources | nindent 10 }}
         volumeMounts:
         {{- range .Values.ingester.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: query
 {{- if .Values.query.annotations }}
   annotations:
-{{ toYaml .Values.query.annotations | indent 4 }}
+    {{- toYaml .Values.query.annotations | nindent 4 }}
 {{- end }}
 spec:
   replicas: {{ .Values.query.replicaCount }}
@@ -22,22 +22,22 @@ spec:
     metadata:
 {{- if .Values.query.podAnnotations }}
       annotations:
-{{ toYaml .Values.query.podAnnotations | indent 8 }}
+        {{- toYaml .Values.query.podAnnotations | nindent 8 }}
 {{- end }}
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: query
 {{- if .Values.query.podLabels }}
-{{ toYaml .Values.query.podLabels | indent 8 }}
+        {{- toYaml .Values.query.podLabels | nindent 8 }}
 {{- end }}
     spec:
       securityContext:
-{{ toYaml .Values.query.podSecurityContext | indent 8 }}
+        {{- toYaml .Values.query.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.query.name" . }}
         securityContext:
-{{ toYaml .Values.query.securityContext | indent 10 }}
+          {{- toYaml .Values.query.securityContext | nindent 10 }}
         image: {{ .Values.query.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         args:
@@ -67,7 +67,7 @@ spec:
           containerPort: 16687
           protocol: TCP
         resources:
-{{ toYaml .Values.query.resources | indent 10 }}
+          {{- toYaml .Values.query.resources | nindent 10 }}
         volumeMounts:
         {{- range .Values.query.extraSecretMounts }}
           - name: {{ .name }}
@@ -106,7 +106,7 @@ spec:
 {{- if .Values.query.agentSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-sidecar
         securityContext:
-{{ toYaml .Values.query.securityContext | indent 10 }}
+          {{- toYaml .Values.query.securityContext | nindent 10 }}
         image: {{ .Values.agent.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -10,7 +10,7 @@ metadata:
     app.kubernetes.io/component: query
   {{- if .Values.query.ingress.annotations }}
   annotations:
-{{ toYaml .Values.query.ingress.annotations | indent 4 }}
+    {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
   {{- end }}
 spec:
   rules:
@@ -25,6 +25,6 @@ spec:
     {{- end -}}
   {{- if .Values.query.ingress.tls }}
   tls:
-{{ toYaml .Values.query.ingress.tls | indent 4 }}
+    {{- toYaml .Values.query.ingress.tls | nindent 4 }}
   {{- end -}}
 {{- end -}}

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: query
 {{- if .Values.query.service.annotations }}
   annotations:
-{{ toYaml .Values.query.service.annotations | indent 4 }}
+    {{- toYaml .Values.query.service.annotations | nindent 4 }}
 {{- end }}
 spec:
   ports:

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -8,7 +8,7 @@ metadata:
     app.kubernetes.io/component: spark
 {{- if .Values.spark.annotations }}
   annotations:
-{{ toYaml .Values.spark.annotations | indent 4 }}
+    {{- toYaml .Values.spark.annotations | nindent 4 }}
 {{- end }}
 spec:
   schedule: {{ .Values.spark.schedule | quote }}
@@ -22,7 +22,7 @@ spec:
             {{- include "jaeger.selectorLabels" . | nindent 12 }}
             app.kubernetes.io/component: spark
             {{- if .Values.spark.podLabels }}
-{{ toYaml .Values.spark.podLabels | indent 12 }}
+            {{- toYaml .Values.spark.podLabels | nindent 12 }}
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.spark.serviceAccountName" . }}
@@ -49,7 +49,7 @@ spec:
               - name: ES_NODES_WAN_ONLY
                 value: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
             resources:
-{{ toYaml .Values.spark.resources | indent 14 }}
+              {{- toYaml .Values.spark.resources | nindent 14 }}
             volumeMounts:
             {{- range .Values.spark.extraConfigmapMounts }}
               - name: {{ .name }}


### PR DESCRIPTION
Use nindent function and indent the templating pipelines where the values will be, instead of indent function without indenting the templating pipelines to improve readability.