### PR TITLE
Added support for specifying the port number to use for the node port  for the Jaeger query service

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.25.0
+version: 0.26.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -301,6 +301,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.podAnnotations` | Annotations for Query pod | `nil` |
 | `query.pullPolicy` | Query UI image pullPolicy | `IfNotPresent` |
 | `query.service.loadBalancerSourceRanges` | list of IP CIDRs allowed access to load balancer (if supported) | `[]` |
+| `query.service.nodePort` | Specific node port to use when type is NodePort | `nil` |
 | `query.service.port` | External accessible port | `80` |
 | `query.service.type` | Service type | `ClusterIP` |
 | `query.basePath` | Base path of Query UI, used for ingress as well (if it is enabled) | `/` |

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -16,6 +16,9 @@ spec:
     port: {{ .Values.query.service.port }}
     protocol: TCP
     targetPort: query
+{{- if and (eq .Values.query.service.type "NodePort") (.Values.query.service.nodePort) }}
+    nodePort: {{ .Values.query.service.nodePort }}
+{{- end }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -337,6 +337,8 @@ query:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     port: 80
+    # Specify a specific node port when type is NodePort
+    # nodePort: 32500
   ingress:
     enabled: false
     annotations: {}


### PR DESCRIPTION
Currently a random node port number is generated for the Jaeger query service when using the NodePort service type. 

This pull request adds support for specifying the port number to use for the node port  for the Jaeger query service.