### PR TITLE
Update cassandra dependency chart version.

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.26.4
+version: 0.26.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/requirements.yaml
+++ b/charts/jaeger/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: cassandra
-    version: ^0.13.1
+    version: ^0.15.0
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: provisionDataStore.cassandra
   - name: elasticsearch


### PR DESCRIPTION
Prior to this version, CRD ServiceMonitor was needed by default.
