### PR TITLE
Allow setting of agent pod priorityClassName

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.26.5
+version: 0.27.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -251,6 +251,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.extraConfigmapMounts` | Additional agent configMap mounts | `[]` |
 | `agent.extraSecretMounts` | Additional agent secret mounts | `[]` |
 | `agent.useHostNetwork` | Enable hostNetwork for agents | `false` |
+| `agent.priorityClassName` | Priority class name for the agent pods | `` |
 | `collector.autoscaling.enabled` | Enable horizontal pod autoscaling | `false` |
 | `collector.autoscaling.minReplicas` | Minimum replicas |  2 |
 | `collector.autoscaling.maxReplicas` | Maximum replicas |  10 |

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -34,6 +34,9 @@ spec:
       hostNetwork: true
       {{- end }}
       dnsPolicy: {{ .Values.agent.dnsPolicy }}
+      {{- with .Values.agent.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       serviceAccountName: {{ template "jaeger.agent.serviceAccountName" . }}
       containers:
       - name: {{ template "jaeger.agent.name" . }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -218,6 +218,7 @@ agent:
   #   readOnly: true
   useHostNetwork: false
   dnsPolicy: ClusterFirst
+  priorityClassName: ""
 
 collector:
   podSecurityContext: {}


### PR DESCRIPTION
We do a lot of autoscaling in our cluster and have run into issues where the Jaeger agent pods end up stuck in `Pending` because other pods with the default priority filled the node before the agent pod could be scheduled. To prevent this, we added the ability to set the `priorityClassName` on the agent pods.