### PR TITLE
Jaeger Chart: Migrate Ingress to non-deprecated apiVersion

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.27.3
+version: 0.28.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.hotrod.ingress.enabled -}}
 {{- $serviceName := include "jaeger.fullname" . -}}
 {{- $servicePort := .Values.hotrod.service.port -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "jaeger.fullname" . }}-hotrod

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -1,7 +1,7 @@
 {{- if .Values.query.ingress.enabled -}}
 {{- $servicePort := .Values.query.service.port -}}
 {{- $basePath := .Values.query.basePath -}}
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: {{ template "jaeger.query.name" . }}


### PR DESCRIPTION
Starting from Kubernetes version `1.16`, Ingress resource is no loger served from `extensions/v1beta1` apiVersion.

In this PR we migrate templates regarding these resources to newer and supported values.