### PR TITLE
feat(jaeger-operator): add namespace to Deplyment, service and jaeger templates

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.18.3
+version: 2.18.4
 appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:

--- a/charts/jaeger-operator/templates/jaeger.yaml
+++ b/charts/jaeger-operator/templates/jaeger.yaml
@@ -3,6 +3,7 @@ apiVersion: jaegertracing.io/v1
 kind: Jaeger
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}-jaeger
+  namespace: {{ default .Release.Namespace .Values.jaeger.namespace }}
 {{- with .Values.jaeger.spec }}
 spec:
 {{ toYaml . | indent 2}}

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "jaeger-operator.fullname" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 spec:

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -13,6 +13,8 @@ crd:
 jaeger:
   # Specifies whether Jaeger instance should be created
   create: false
+  # namespace where Jaeger resource should be created default to .Release.Namespace
+  namespace:
   spec: {}
 
 rbac:


### PR DESCRIPTION
For consistency, and those who use `helm template`, `namespace` was added in the `metadata` of the Deployment, service and jaeger.

For `jaeger`, it was given more flexibility to namespace it allowing to customize via `.Values.jaeger.namespace` otherwise will be defaulted to `.Release.Namespace` 