### PR TITLE
Add custom SecretKey Option for Elasticsearch

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.17.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.28.0
+version: 0.29.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -346,6 +346,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `storage.elasticsearch.env` | Extra ES related env vars to be configured on components that talk to ES | `nil` |
 | `storage.elasticsearch.cmdlineParams` | Extra ES related command line options to be configured on components that talk to ES | `nil` |
 | `storage.elasticsearch.existingSecret` | Name of existing password secret object (for password authentication | `nil` |
+| `storage.elasticsearch.existingSecretKey` | Key of the declared password secret | `password` |
 | `storage.elasticsearch.host` | Provisioned elasticsearch host| `elasticsearch` |
 | `storage.elasticsearch.password` | Provisioned elasticsearch password  (ignored if storage.elasticsearch.existingSecret set | `changeme` |
 | `storage.elasticsearch.port` | Provisioned elasticsearch port| `9200` |

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -303,7 +303,7 @@ Elasticsearch related environment variables
   valueFrom:
     secretKeyRef:
       name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
-      key: password
+      key: {{ default "password" .Values.storage.elasticsearch.existingSecretKey }}
 {{- end }}
 {{- if .Values.storage.elasticsearch.indexPrefix }}
 - name: ES_INDEX_PREFIX

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -49,6 +49,7 @@ storage:
     # indexPrefix: test
     ## Use existing secret (ignores previous password)
     # existingSecret:
+    # existingSecretKey:
     nodesWanOnly: false
     env: {}
     ## ES related env vars to be configured on the concerned components


### PR DESCRIPTION
I was deploying Jeager with an Elasticsearch Backend. But I didn't use the elasticsearch Subchart but a custom chart, which supports the creation of Elastic related crds provided by the ECK Operator (https://github.com/elastic/cloud-on-k8s). When deploying an elasticsearch cluster via eck-operator there will be a secret created with the credentials for the elastic user. The difference is, that the credentials are stored under the .elastic key in the secret. To resolve this issue I added an Option to define the key within the referenced secret.