### PR TITLE
[jaeger-operator] fix ingress role permissions

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.15.0
+version: 2.15.1
 appVersion: 1.18.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/role.yaml
+++ b/charts/jaeger-operator/templates/role.yaml
@@ -30,6 +30,12 @@ rules:
   verbs:
   - '*'
 - apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingresses
+  verbs:
+  - '*'
+- apiGroups:
   - monitoring.coreos.com
   resources:
   - servicemonitors


### PR DESCRIPTION
On newer k8s clusters, the api group for ingresses has somehow changed. This should fix #112