### PR TITLE
[jaeger] use extraEnv in favor of env

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,18 +14,18 @@ jobs:
 
       - name: Run chart-testing (lint)
         id: lint
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.0.0-rc.1
         with:
           installLocalPathProvisioner: true
         # Only build a kind cluster if there are chart changes to test.
         if: steps.lint.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        uses: helm/chart-testing-action@v1.0.0-rc.2
         with:
           command: install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -35,6 +35,6 @@ jobs:
           helm repo add elastic https://helm.elastic.co
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.0.0-alpha.2
+        uses: helm/chart-releaser-action@v1.0.0-rc.2
         env:
           CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.31.0
+version: 0.32.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -184,6 +184,7 @@ spark:
 ```
 
 Generate configmap jaeger-tls:
+
 ```bash
 keytool -import -trustcacerts -keystore trust.store -storepass changeit -alias es-root -file es.pem
 kubectl create configmap jaeger-tls --from-file=trust.store --from-file=es.pem
@@ -227,7 +228,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `<agent\|collector\|query\|ingester>.cmdlineParams` | Additional command line parameters | `nil` |
-| `<component>.env` | Additional environment variables | {} |
+| `<component>.extraEnv` | Additional environment variables | [] |
 | `<component>.nodeSelector` | Node selector | {} |
 | `<component>.tolerations` | Node tolerations | [] |
 | `<component>.affinity` | Affinity | {} |
@@ -235,9 +236,9 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `<component>.podSecurityContext` | Pod security context | {} |
 | `<component>.securityContext` | Container security context | {} |
 | `<component>.serviceAccount.create` | Create service account | `true` |
-| `<component>.serviceAccount.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `` |
+| `<component>.serviceAccount.name` | The name of the ServiceAccount to use. If not set and create is true, a name is generated using the fullname template | `nil` |
 | `<component>.serviceMonitor.enabled` | Create serviceMonitor | `false` |
-| `<component>.serviceMonitor.additionalLables` | Add additional labels to serviceMonitor | {} |
+| `<component>.serviceMonitor.additionalLabels` | Add additional labels to serviceMonitor | {} |
 | `agent.annotations` | Annotations for Agent | `nil` |
 | `agent.dnsPolicy` | Configure DNS policy for agents | `ClusterFirst` |
 | `agent.service.annotations` | Annotations for Agent SVC | `nil` |
@@ -253,7 +254,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `agent.extraConfigmapMounts` | Additional agent configMap mounts | `[]` |
 | `agent.extraSecretMounts` | Additional agent secret mounts | `[]` |
 | `agent.useHostNetwork` | Enable hostNetwork for agents | `false` |
-| `agent.priorityClassName` | Priority class name for the agent pods | `` |
+| `agent.priorityClassName` | Priority class name for the agent pods | `nil` |
 | `collector.autoscaling.enabled` | Enable horizontal pod autoscaling | `false` |
 | `collector.autoscaling.minReplicas` | Minimum replicas |  2 |
 | `collector.autoscaling.maxReplicas` | Maximum replicas |  10 |
@@ -309,12 +310,10 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `schema.annotations` | Annotations for the schema job| `nil` |
 | `schema.extraConfigmapMounts` | Additional cassandra schema job configMap mounts | `[]`  |
 | `schema.image` | Image to setup cassandra schema | `jaegertracing/jaeger-cassandra-schema` |
-| `schema.env` | Environment variables for cassandra-schema-job | `MODE: prod` |
 | `schema.pullPolicy` | Schema image pullPolicy | `IfNotPresent` |
 | `schema.activeDeadlineSeconds` | Deadline in seconds for cassandra schema creation job to complete | `120` |
 | `schema.keyspace` | Set explicit keyspace name | `nil` |
 | `spark.enabled` | Enables the dependencies job| `false` |
-| `spark.extraEnv` | Additional environment variables | {} |
 | `spark.image` | Image for the dependencies job| `jaegertracing/spark-dependencies` |
 | `spark.pullPolicy` | Image pull policy of the deps image | `Always` |
 | `spark.schedule` | Schedule of the cron job | `"49 23 * * *"` |

--- a/charts/jaeger/templates/NOTES.txt
+++ b/charts/jaeger/templates/NOTES.txt
@@ -1,3 +1,9 @@
+
+###################################################################
+### IMPORTANT: The use of <component>.env: {...} is deprecated. ###
+### Please use <component>.extraEnv: [] instead.                ###
+###################################################################
+
 You can log into the Jaeger Query UI here:
 
 {{- if contains "NodePort" .Values.query.service.type }}

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -288,6 +288,9 @@ Cassandra related environment variables
 - name: {{ $key | quote }}
   value: {{ $value | quote }}
 {{ end -}}
+{{- if .Values.storage.cassandra.extraEnv }}
+{{ toYaml .Values.storage.cassandra.extraEnv }}
+{{- end }}
 {{- end -}}
 
 {{/*
@@ -313,6 +316,9 @@ Elasticsearch related environment variables
 - name: {{ $key | quote }}
   value: {{ $value | quote }}
 {{ end -}}
+{{- if .Values.storage.elasticsearch.extraEnv }}
+{{ toYaml .Values.storage.elasticsearch.extraEnv }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -53,9 +53,12 @@ spec:
           {{- end }}
           {{- end }}
         env:
+        {{- if .Values.agent.extraEnv }}
+          {{- toYaml .Values.agent.extraEnv | nindent 10 }}
+        {{- end }}
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
-        - name: REPORTER_GRPC_HOST_PORT
-          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
+          - name: REPORTER_GRPC_HOST_PORT
+            value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
         ports:
         - name: zipkin-compact

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -31,23 +31,26 @@ spec:
         image: {{ .Values.schema.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         env:
-        {{ range $key, $value := .Values.schema.env }}
-        - name: {{ $key | quote }}
-          value: {{ $value | quote }}
-        {{ end }}
-        {{- include "cassandra.env" . | nindent 8 }}
-        - name: CQLSH_HOST
-          value: {{ template "cassandra.host" . }}
-        {{ if .Values.storage.cassandra.tls.enabled }}
-        - name: CQLSH_SSL
-          value: "--ssl"
+        {{- if .Values.schema.extraEnv }}
+          {{- toYaml .Values.schema.extraEnv | nindent 10 }}
         {{- end }}
-        - name: DATACENTER
-          value: {{ .Values.cassandra.config.dc_name | quote }}
-      {{- if .Values.storage.cassandra.keyspace }}
-        - name: KEYSPACE
-          value: {{ .Values.storage.cassandra.keyspace }}
-      {{- end }}
+          {{ range $key, $value := .Values.schema.env }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{ end }}
+          {{- include "cassandra.env" . | nindent 10 }}
+          - name: CQLSH_HOST
+            value: {{ template "cassandra.host" . }}
+          {{ if .Values.storage.cassandra.tls.enabled }}
+          - name: CQLSH_SSL
+            value: "--ssl"
+          {{- end }}
+          - name: DATACENTER
+            value: {{ .Values.cassandra.config.dc_name | quote }}
+        {{- if .Values.storage.cassandra.keyspace }}
+          - name: KEYSPACE
+            value: {{ .Values.storage.cassandra.keyspace }}
+        {{- end }}
         resources:
           {{- toYaml .Values.schema.resources | nindent 10 }}
         volumeMounts:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -66,6 +66,9 @@ spec:
           - name: {{ $key | quote }}
             value: {{ $value | quote }}
           {{- end }}
+        {{- if .Values.storage.kafka.extraEnv }}
+          {{- toYaml .Values.storage.kafka.extraEnv | nindent 10 }}
+        {{- end }}
           - name: KAFKA_PRODUCER_BROKERS
             value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers }}
           - name: KAFKA_PRODUCER_TOPIC

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -41,13 +41,12 @@ spec:
             image: "{{ .Values.esIndexCleaner.image }}:{{ .Values.esIndexCleaner.tag }}"
             imagePullPolicy: {{ .Values.esIndexCleaner.pullPolicy }}
             args:
-            - {{ .Values.esIndexCleaner.numberOfDays | quote }}
-            - {{ include "elasticsearch.client.url" . }}
+              - {{ .Values.esIndexCleaner.numberOfDays | quote }}
+              - {{ include "elasticsearch.client.url" . }}
             env:
-              {{- range $key, $value := .Values.esIndexCleaner.env }}
-              - name: {{ $key | quote }}
-                value: {{ $value | quote }}
-              {{- end }}
+            {{- if .Values.esIndexCleaner.extraEnv }}
+              {{- toYaml .Values.esIndexCleaner.extraEnv | nindent 14 }}
+            {{- end }}
               {{ include "elasticsearch.env" . | nindent 14 }}
             resources:
               {{- toYaml .Values.esIndexCleaner.resources | nindent 14 }}

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -57,6 +57,9 @@ spec:
           {{- end }}
           {{- include "storage.cmdArgs" . | nindent 10 }}
         env:
+        {{- if .Values.ingester.extraEnv }}
+          {{- toYaml .Values.ingester.extraEnv | nindent 10 }}
+        {{- end }}
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
           {{- include "storage.env" . | nindent 10 }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -50,6 +50,9 @@ spec:
           {{- end }}
           {{- include "storage.cmdArgs" . | nindent 10 }}
         env:
+        {{- if .Values.query.extraEnv }}
+          {{- toYaml .Values.query.extraEnv | nindent 10 }}
+        {{- end }}
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
           {{- include "storage.env" . | nindent 10 }}

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -42,7 +42,9 @@ spec:
               - name: STORAGE
                 value: {{ .Values.storage.type }}
               {{- include "storage.env" . | nindent 14 }}
+            {{- if .Values.spark.extraEnv }}
               {{- toYaml .Values.spark.extraEnv | nindent 14 }}
+            {{- end }}
               - name: CASSANDRA_CONTACT_POINTS
                 value: {{ include "cassandra.contact_points" . }}
               - name: ES_NODES

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -28,11 +28,15 @@ storage:
     ## Use existing secret (ignores previous password)
     # existingSecret:
     ## Cassandra related env vars to be configured on the concerned components
-    env: {}
-      # CASSANDRA_SERVERS: cassandra
-      # CASSANDRA_PORT: 9042
-      # CASSANDRA_KEYSPACE: jaeger_v1_test
-      # CASSANDRA_TLS_ENABLED: false
+    extraEnv: []
+      # - name: CASSANDRA_SERVERS
+      #   value: cassandra
+      # - name: CASSANDRA_PORT
+      #   value: 9042
+      # - name: CASSANDRA_KEYSPACE
+      #   value: jaeger_v1_test
+      # - name: CASSANDRA_TLS_ENABLED
+      #   value: false
     ## Cassandra related cmd line opts to be configured on the concerned components
     cmdlineParams: {}
       # cassandra.servers: cassandra
@@ -51,11 +55,14 @@ storage:
     # existingSecret:
     # existingSecretKey:
     nodesWanOnly: false
-    env: {}
+    extraEnv: []
     ## ES related env vars to be configured on the concerned components
-      # ES_SERVER_URLS: http://elasticsearch-master:9200
-      # ES_USERNAME: elastic
-      # ES_INDEX_PREFIX: test
+      # - name: ES_SERVER_URLS
+      #   value: http://elasticsearch-master:9200
+      # - name: ES_USERNAME
+      #   value: elastic
+      # - name: ES_INDEX_PREFIX
+      #   value: test
     ## ES related cmd line opts to be configured on the concerned components
     cmdlineParams: {}
       # es.server-urls: http://elasticsearch-master:9200
@@ -66,6 +73,7 @@ storage:
       - kafka:9092
     topic: jaeger_v1_test
     authentication: none
+    extraEnv: []
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:
@@ -113,10 +121,13 @@ schema:
   podLabels: {}
   ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 300
-  env:
-    MODE: prod
-    # TRACE_TTL: 172800
-    # DEPENDENCIES_TTL: 0
+  extraEnv: []
+    # - name: MODE
+    #   value: prod
+    # - name: TRACE_TTL
+    #   value: 172800
+    # - name: DEPENDENCIES_TTL
+    #   value: 0
 
 # For configurable values of the elasticsearch if provisioned, please see:
 # https://github.com/elastic/helm-charts/tree/master/elasticsearch#configuration
@@ -131,7 +142,6 @@ ingester:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  env: {}
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -176,7 +186,7 @@ agent:
   image: jaegertracing/jaeger-agent
   pullPolicy: IfNotPresent
   cmdlineParams: {}
-  env: {}
+  extraEnv: []
   daemonset:
     useHostPort: false
   service:
@@ -238,7 +248,6 @@ collector:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  env: {}
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -337,7 +346,7 @@ query:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
-  env: {}
+  extraEnv: []
   replicaCount: 1
   service:
     annotations: {}
@@ -441,6 +450,7 @@ esIndexCleaner:
   tag: latest
   pullPolicy: Always
   cmdlineParams: {}
+  extraEnv: []
   schedule: "55 23 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,4 @@ chart-dirs:
 chart-repos:
   - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
   - elastic=https://helm.elastic.co
-helm-extra-args: --timeout=600
+helm-extra-args: --timeout=600s


### PR DESCRIPTION
fixes #120
fixes #124 

env was limited in its implementation, extraEnv takes a list and performs a toYaml to enable maxiumum flexibility such as values from secrets and configmaps

cc @cgroschupp @Jasstkn can you please review if you get a chance?