### PR TITLE
[jaeger] Added PriorityClassName Configuration to Collector and Query

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.34.0
+version: 0.34.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -273,6 +273,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `collector.extraConfigmapMounts` | Additional collector configMap mounts | `[]` |
 | `collector.extraSecretMounts` | Additional collector secret mounts | `[]` |
 | `collector.samplingConfig` | [Sampling strategies json file](https://www.jaegertracing.io/docs/latest/sampling/#collector-sampling-configuration) | `nil` |
+| `collector.priorityClassName` | Priority class name for the collector pods | `nil` |
 | `ingester.enabled` | Enable ingester component, collectors will write to Kafka | `false` |
 | `ingester.autoscaling.enabled` | Enable horizontal pod autoscaling | `false` |
 | `ingester.autoscaling.minReplicas` | Minimum replicas |  2 |
@@ -312,6 +313,7 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `query.service.type` | Service type | `ClusterIP` |
 | `query.basePath` | Base path of Query UI, used for ingress as well (if it is enabled) | `/` |
 | `query.extraConfigmapMounts` | Additional query configMap mounts | `[]` |
+| `query.priorityClassName` | Priority class name for the Query UI pods | `nil` |
 | `schema.annotations` | Annotations for the schema job| `nil` |
 | `schema.extraConfigmapMounts` | Additional cassandra schema job configMap mounts | `[]`  |
 | `schema.image` | Image to setup cassandra schema | `jaegertracing/jaeger-cassandra-schema` |

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -34,6 +34,9 @@ spec:
         {{- toYaml .Values.collector.podLabels | nindent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.collector.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.collector.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -31,6 +31,9 @@ spec:
         {{- toYaml .Values.query.podLabels | nindent 8 }}
 {{- end }}
     spec:
+      {{- with .Values.query.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       securityContext:
         {{- toYaml .Values.query.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -337,6 +337,7 @@ collector:
   #       "param": 1
   #     }
   #   }
+  priorityClassName: ""
   serviceMonitor:
     enabled: false
     additionalLabels: {}
@@ -400,6 +401,7 @@ query:
   #   subPath: ""
   #   configMap: jaeger-config
   #   readOnly: true
+  priorityClassName: ""
   serviceMonitor:
     enabled: false
     additionalLabels: {}


### PR DESCRIPTION
We'd like to set a `priortiyClass` not only for the agents, but for the `Collector` and `Query-UI` as well.

This PR adds this possibility.

Signed-off-by: David Losert <david.losert@gmx.de>