### PR TITLE
[jaeger] Have an ability to make collector svc headless

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.62.2
+version: 0.63.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.62.1
+version: 0.62.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -57,9 +57,9 @@ spec:
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector
+  {{- if and (eq .Values.collector.service.type "ClusterIP") .Values.collector.service.clusterIP }}
+  clusterIP: {{ .Values.collector.service.clusterIP }}
+  {{- end }}
   type: {{ .Values.collector.service.type }}
-{{- if and (eq .Values.collector.service.type "LoadBalancer") .Values.collector.service.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.collector.service.loadBalancerIP }}
-{{- end -}}
 {{- template "loadBalancerSourceRanges" .Values.collector }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -321,6 +321,8 @@ collector:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
+    # Cluster IP address to assign to service. Set to None to make service headless
+    clusterIP: ""
     grpc:
       port: 14250
       # nodePort:


### PR DESCRIPTION
Hi. 
gRPC client balancing requires headless services in order to work. More info here - <https://kubernetes.io/blog/2018/11/07/grpc-load-balancing-on-kubernetes-without-tears/>
This change allows to set collector service type to headless. We use it in production without problems.