### PR TITLE
[jaeger-operator] Fix whitespace typo in post-install notes

### DIFF
--- a/charts/jaeger-operator/templates/NOTES.txt
+++ b/charts/jaeger-operator/templates/NOTES.txt
@@ -2,7 +2,7 @@ jaeger-operator is installed.
 
 
 Check the jaeger-operator logs
-  export POD=$(kubectl get pods-l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
+  export POD=$(kubectl get pods -lapp.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
   kubectl logs $POD --namespace={{ .Release.Namespace }}
 
 


### PR DESCRIPTION
Just a minor typographic fix.  The command as originally written doesn't work because `get pods-l` isn't a valid kubectl command.