### PR TITLE
Allow overriding the Cassandra schema job security context

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.33.0
+version: 0.34.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -25,6 +25,8 @@ spec:
         {{- toYaml .Values.schema.podLabels | nindent 8 }}
 {{- end }}
     spec:
+      securityContext:
+        {{- toYaml .Values.schema.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
       {{- with .Values.schema.imagePullSecrets }}
       imagePullSecrets:
@@ -34,6 +36,8 @@ spec:
       - name: {{ include "jaeger.fullname" . }}-cassandra-schema
         image: {{ .Values.schema.image }}:{{ .Values.tag }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
+        securityContext:
+          {{- toYaml .Values.schema.securityContext | nindent 10 }}
         env:
         {{- if .Values.schema.extraEnv }}
           {{- toYaml .Values.schema.extraEnv | nindent 10 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -120,6 +120,8 @@ schema:
     name:
   podAnnotations: {}
   podLabels: {}
+  securityContext: {}
+  podSecurityContext: {}
   ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 300
   extraEnv: []


### PR DESCRIPTION
Similar to the existing deployment objects, this adds support for overriding the Cassandra schema job's securityContext.