### PR TITLE
Use bitnami chart for kafka

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,7 @@ jobs:
           helm repo add stable https://kubernetes-charts.storage.googleapis.com/
           helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
           helm repo add elastic https://helm.elastic.co
+          helm repo add bitnami https://charts.bitnami.com/bitnami
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-rc.2

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 # Helm chart automated files
 /charts/*/charts
 /charts/*/requirements.lock
+/charts/*/*.tgz

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.36.0
+version: 0.37.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/requirements.yaml
+++ b/charts/jaeger/requirements.yaml
@@ -8,6 +8,6 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^0.20.6
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+    version: ^11.8.4
+    repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -90,11 +90,13 @@ cassandra:
 
 # Begin: Override values on the Kafka subchart to customize for Jaeger
 kafka:
-  replicas: 1
-  configurationOverrides:
-    "auto.create.topics.enable": true
+  replicaCount: 1
+  autoCreateTopicsEnable: true
   zookeeper:
     replicaCount: 1
+    serviceAccount:
+      create: true
+
 # End: Override values on the Kafka subchart to customize for Jaeger
 
 # Begin: Default values for the various components of Jaeger

--- a/ct.yaml
+++ b/ct.yaml
@@ -5,4 +5,5 @@ chart-dirs:
 chart-repos:
   - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
   - elastic=https://helm.elastic.co
+  - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout=600s


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

Resolves https://github.com/jaegertracing/helm-charts/issues/149

Incubator kafka chart will be obsolete soon as per these instructions: https://github.com/helm/charts#deprecation-timeline
Also liveness probe was failing for the incubator kafka chart.

Bitnami provides stable kafka chart that Jaeger's helm chart can use.