### PR TITLE
[jaeger-operator] fix metrics service selector labels and add servicemonitor

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.17.0
+version: 2.18.0
 appVersion: 1.19.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -11,6 +11,5 @@ spec:
     protocol: TCP
     targetPort: 8383
   selector:
-    app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+{{ include "jaeger-operator.labels" . | indent 4 }}
   type: ClusterIP

--- a/charts/jaeger-operator/templates/servicemonitor.yaml
+++ b/charts/jaeger-operator/templates/servicemonitor.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.metrics.serviceMonitor.enabled -}}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "jaeger-operator.fullname" . }}-metrics
+  labels:
+{{ include "jaeger-operator.labels" . | indent 4 }}
+spec:
+  endpoints:
+    - port: metrics
+      {{- if .Values.metrics.serviceMonitor.scrapeInterval }}
+      interval: {{ .Values.metrics.serviceMonitor.scrapeInterval }}
+      {{- end }}
+  selector:
+    matchLabels:
+      {{ include "jaeger-operator.labels" . | indent 6 }}
+{{- end }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -43,3 +43,8 @@ tolerations: []
 affinity: {}
 
 securityContext: {}
+
+metrics:
+  serviceMonitor:
+    enabled: false
+    # scrapeInterval: 15s


### PR DESCRIPTION
This issue will fix #141 

The service selector labels were incorrectly set, so they haven't matched the deployed Pods.
Added servicemonitor resource to the Helm chart, which is currently be deployed by jaeger-operator itself and will be fixed by https://github.com/jaegertracing/jaeger-operator/pull/1201.
