### PR TITLE
[jaeger] Adding quotes to the cassandra.tls.enabled parameter

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.37.1
+version: 0.37.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -42,7 +42,7 @@ storage:
       # cassandra.servers: cassandra
       # cassandra.port: 9042
       # cassandra.keyspace: jaeger_v1_test
-      # cassandra.tls.enabled: false
+      # cassandra.tls.enabled: "false"
   elasticsearch:
     scheme: http
     host: elasticsearch-master


### PR DESCRIPTION
Signed-off-by: Michael Lundquist <michaellundquist7@gmail.com>

#### What this PR does

Fixes commented out cassandra parameter format

#### Which issue this PR fixes

#153 

#### fixes 

Adding quotes to the cassandra.tls.enabled parameter so it can be passed correctly

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
