### PR TITLE
[jaeger] Fixing issue 158

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.37.1
+version: 0.37.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -337,7 +337,7 @@ Cassandra related command line options
 */}}
 {{- define "cassandra.cmdArgs" -}}
 {{- range $key, $value := .Values.storage.cassandra.cmdlineParams -}}
-{{- if $value -}}
+{{- if $value }}
 - --{{ $key }}={{ $value }}
 {{- else }}
 - --{{ $key }}
@@ -350,7 +350,7 @@ Elasticsearch related command line options
 */}}
 {{- define "elasticsearch.cmdArgs" -}}
 {{- range $key, $value := .Values.storage.elasticsearch.cmdlineParams -}}
-{{- if $value -}}
+{{- if $value }}
 - --{{ $key }}={{ $value }}
 {{- else }}
 - --{{ $key }}


### PR DESCRIPTION
#### What this PR does

Fixing how storage.cassandra.cmdlineParams and storage.elasticsearch cmdlineParams are parsed in storage.cmdArgs in _helpers.tpl.

#### Which issue this PR fixes

- fixes #158

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
