### PR TITLE
[jaeger] Add elasticsearch rollover jobs

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.37.2
+version: 0.38.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -342,6 +342,27 @@ The following table lists the configurable parameters of the Jaeger chart and th
 | `esIndexCleaner.tag` | Tag of the dependencies job image | `latest` |
 | `esIndexCleaner.extraConfigmapMounts` | Additional esIndexCleaner configMap mounts | `[]` |
 | `esIndexCleaner.extraSecretMounts` | Additional esIndexCleaner secret mounts | `[]` |
+| `esRollover.enabled` | Enables the ElasticSearch rollover job | `false` |
+| `esRollover.image` | Image for the ElasticSearch rollover job | `jaegertracing/jaeger-es-rollover` |
+| `esRollover.imagePullSecrets` | Secret to pull the Image for the ElasticSearch rollover job | `[]` |
+| `esRollover.pullPolicy` | Image pull policy of the ES rollover image | `Always` |
+| `esRollover.schedule` | Schedule of the cron job | `"10 0 * * *"` |
+| `esRollover.successfulJobsHistoryLimit` | successfulJobsHistoryLimit for ElasticSearch rollover CronJob | `3` |
+| `esRollover.failedJobsHistoryLimit` | failedJobsHistoryLimit for ElasticSearch rollover CronJob | `3` |
+| `esRollover.tag` | Tag of the rollover job image | `latest` |
+| `esRollover.extraConfigmapMounts` | Additional esRollover configMap mounts | `[]` |
+| `esRollover.extraSecretMounts` | Additional esRollover secret mounts | `[]` |
+| `esRollover.initHook.ttlSecondsAfterFinished` | ttlSecondsAfterFinished for ElasticSearch rollover init hook | `120` |
+| `esLookback.enabled` | Enables the ElasticSearch rollover lookback job | `false` |
+| `esLookback.image` | Image for the ElasticSearch rollover lookback job | `jaegertracing/jaeger-es-rollover` |
+| `esLookback.imagePullSecrets` | Secret to pull the Image for the ElasticSearch rollover lookback job | `[]` |
+| `esLookback.pullPolicy` | Image pull policy of the ES rollover image | `Always` |
+| `esLookback.schedule` | Schedule of the cron job | `"5 0 * * *"` |
+| `esLookback.successfulJobsHistoryLimit` | successfulJobsHistoryLimit for ElasticSearch rollover lookback CronJob | `3` |
+| `esLookback.failedJobsHistoryLimit` | failedJobsHistoryLimit for ElasticSearch rollover lookback CronJob | `3` |
+| `esLookback.tag` | Tag of the rollover lookback job image | `latest` |
+| `esLookback.extraConfigmapMounts` | Additional esLookback configMap mounts | `[]` |
+| `esLookback.extraSecretMounts` | Additional esLookback secret mounts | `[]` |
 | `storage.cassandra.env` | Extra cassandra related env vars to be configured on components that talk to cassandra | `cassandra` |
 | `storage.cassandra.cmdlineParams` | Extra cassandra related command line options to be configured on components that talk to cassandra | `cassandra` |
 | `storage.cassandra.existingSecret` | Name of existing password secret object (for password authentication | `nil`

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -85,6 +85,28 @@ Create the name of the esIndexCleaner service account to use
 {{- end -}}
 
 {{/*
+Create the name of the esRollover service account to use
+*/}}
+{{- define "jaeger.esRollover.serviceAccountName" -}}
+{{- if .Values.esRollover.serviceAccount.create -}}
+  {{ default (printf "%s-es-rollover" (include "jaeger.fullname" .)) .Values.esRollover.serviceAccount.name }}
+{{- else -}}
+  {{ default "default" .Values.esRollover.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create the name of the esLookback service account to use
+*/}}
+{{- define "jaeger.esLookback.serviceAccountName" -}}
+{{- if .Values.esLookback.serviceAccount.create -}}
+  {{ default (printf "%s-es-lookback" (include "jaeger.fullname" .)) .Values.esLookback.serviceAccount.name }}
+{{- else -}}
+  {{ default "default" .Values.esLookback.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create the name of the hotrod service account to use
 */}}
 {{- define "jaeger.hotrod.serviceAccountName" -}}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.esLookback.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "jaeger.fullname" . }}-es-lookback
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-lookback
+{{- if .Values.esLookback.annotations }}
+  annotations:
+    {{- toYaml .Values.esLookback.annotations | nindent 4 }}
+{{- end }}
+spec:
+  concurrencyPolicy: "Forbid"
+  schedule: {{ .Values.esLookback.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.esLookback.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.esLookback.failedJobsHistoryLimit }}
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- if .Values.esLookback.podAnnotations }}
+          annotations:
+            {{- toYaml .Values.esLookback.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "jaeger.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: es-lookback
+            {{- if .Values.esLookback.podLabels }}
+            {{- toYaml .Values.esLookback.podLabels | nindent 12 }}
+            {{- end }}
+        spec:
+          serviceAccountName: {{ template "jaeger.esLookback.serviceAccountName" . }}
+          {{- with .Values.esLookback.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.esLookback.podSecurityContext | nindent 12 }}
+          restartPolicy: OnFailure
+          {{- with .Values.esLookback.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.esLookback.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.esLookback.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          containers:
+          - name: {{ include "jaeger.fullname" . }}-es-lookback
+            securityContext:
+              {{- toYaml .Values.esLookback.securityContext | nindent 14 }}
+            image: "{{ .Values.esLookback.image }}:{{ .Values.esLookback.tag }}"
+            imagePullPolicy: {{ .Values.esLookback.pullPolicy }}
+            args:
+              - lookback
+              - {{ include "elasticsearch.client.url" . }}
+            env:
+              {{ include "elasticsearch.env" . | nindent 14 }}
+              {{- if .Values.esLookback.extraEnv }}
+                {{- toYaml .Values.esLookback.extraEnv | nindent 14 }}
+              {{- end }}
+            resources:
+              {{- toYaml .Values.esLookback.resources | nindent 14 }}
+            volumeMounts:
+            {{- range .Values.esLookback.extraConfigmapMounts }}
+              - name: {{ .name }}
+                mountPath: {{ .mountPath }}
+                subPath: {{ .subPath }}
+                readOnly: {{ .readOnly }}
+            {{- end }}
+            {{- range .Values.esLookback.extraSecretMounts }}
+              - name: {{ .name }}
+                mountPath: {{ .mountPath }}
+                subPath: {{ .subPath }}
+                readOnly: {{ .readOnly }}
+            {{- end }}
+{{- end -}}

--- a/charts/jaeger/templates/es-lookback-sa.yaml
+++ b/charts/jaeger/templates/es-lookback-sa.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.esLookback.enabled .Values.esLookback.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jaeger.esLookback.serviceAccountName" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-lookback
+{{- end -}}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -1,0 +1,84 @@
+{{- if .Values.esRollover.enabled -}}
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "jaeger.fullname" . }}-es-rollover
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-rollover
+{{- if .Values.esRollover.annotations }}
+  annotations:
+    {{- toYaml .Values.esRollover.annotations | nindent 4 }}
+{{- end }}
+spec:
+  concurrencyPolicy: "Forbid"
+  schedule: {{ .Values.esRollover.schedule | quote }}
+  successfulJobsHistoryLimit: {{ .Values.esRollover.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.esRollover.failedJobsHistoryLimit }}
+  suspend: false
+  jobTemplate:
+    spec:
+      template:
+        metadata:
+          {{- if .Values.esRollover.podAnnotations }}
+          annotations:
+            {{- toYaml .Values.esRollover.podAnnotations | nindent 12 }}
+          {{- end }}
+          labels:
+            {{- include "jaeger.selectorLabels" . | nindent 12 }}
+            app.kubernetes.io/component: es-rollover
+            {{- if .Values.esRollover.podLabels }}
+            {{- toYaml .Values.esRollover.podLabels | nindent 12 }}
+            {{- end }}
+        spec:
+          serviceAccountName: {{ template "jaeger.esRollover.serviceAccountName" . }}
+          {{- with .Values.esRollover.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          securityContext:
+            {{- toYaml .Values.esRollover.podSecurityContext | nindent 12 }}
+          restartPolicy: OnFailure
+          {{- with .Values.esRollover.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.esRollover.affinity }}
+          affinity:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.esRollover.tolerations }}
+          tolerations:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+
+          containers:
+          - name: {{ include "jaeger.fullname" . }}-es-rollover
+            securityContext:
+              {{- toYaml .Values.esRollover.securityContext | nindent 14 }}
+            image: "{{ .Values.esRollover.image }}:{{ .Values.esRollover.tag }}"
+            imagePullPolicy: {{ .Values.esRollover.pullPolicy }}
+            args:
+              - rollover
+              - {{ include "elasticsearch.client.url" . }}
+            env:
+              {{ include "elasticsearch.env" . | nindent 14 }}
+              {{- if .Values.esRollover.extraEnv }}
+                {{- toYaml .Values.esRollover.extraEnv | nindent 14 }}
+              {{- end }}
+            resources:
+              {{- toYaml .Values.esRollover.resources | nindent 14 }}
+            volumeMounts:
+            {{- range .Values.esRollover.extraConfigmapMounts }}
+              - name: {{ .name }}
+                mountPath: {{ .mountPath }}
+                subPath: {{ .subPath }}
+                readOnly: {{ .readOnly }}
+            {{- end }}
+            {{- range .Values.esRollover.extraSecretMounts }}
+              - name: {{ .name }}
+                mountPath: {{ .mountPath }}
+                subPath: {{ .subPath }}
+                readOnly: {{ .readOnly }}
+            {{- end }}
+{{- end -}}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -1,0 +1,75 @@
+{{- if .Values.esRollover.enabled -}}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "jaeger.fullname" . }}-es-rollover-init
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-rollover-init
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+    {{- if .Values.esRollover.initHook.annotations }}
+      {{- toYaml .Values.esRollover.initHook.annotations | nindent 4 }}
+    {{- end }}
+spec:
+  {{- with .Values.esRollover.initHook.ttlSecondsAfterFinished }}
+  ttlSecondsAfterFinished: {{ . }}
+  {{- end }}
+
+  template:
+    metadata:
+      {{- with .Values.esRollover.initHook.podAnnotations }}
+      annotations: {{- toYaml . | nindent 6 }}
+      {{- end }}
+      labels:
+        {{- include "jaeger.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: es-rollover-init
+        {{- if .Values.esRollover.initHook.podLabels }}
+          {{- toYaml .Values.esRollover.initHook.podLabels | nindent 10 }}
+        {{- end }}
+    spec:
+      serviceAccountName: {{ template "jaeger.esRollover.serviceAccountName" . }}
+      {{- with .Values.esRollover.imagePullSecrets }}
+      imagePullSecrets: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      securityContext: {{- toYaml .Values.esRollover.podSecurityContext | nindent 8 }}
+      restartPolicy: OnFailure
+      {{- with .Values.esRollover.nodeSelector }}
+      nodeSelector: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.esRollover.affinity }}
+      affinity: {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.esRollover.tolerations }}
+      tolerations: {{- toYaml . | nindent 8 }}
+      {{- end }}
+
+      containers:
+        - name: {{ include "jaeger.fullname" . }}-es-rollover-init
+          securityContext: {{- toYaml .Values.esRollover.securityContext | nindent 12 }}
+          image: "{{ .Values.esRollover.image }}:{{ .Values.esRollover.tag }}"
+          imagePullPolicy: {{ .Values.esRollover.pullPolicy }}
+          args:
+            - init
+            - {{ include "elasticsearch.client.url" . }}
+          env:
+            {{ include "elasticsearch.env" . | nindent 12 }}
+            {{- with .Values.esRollover.initHook.extraEnv }}
+              {{- toYaml . | nindent 12 }}
+            {{- end }}
+          resources: {{- toYaml .Values.esRollover.resources | nindent 12 }}
+          volumeMounts:
+          {{- range .Values.esRollover.extraConfigmapMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+          {{- range .Values.esRollover.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+          {{- end }}
+{{- end -}}

--- a/charts/jaeger/templates/es-rollover-sa.yaml
+++ b/charts/jaeger/templates/es-rollover-sa.yaml
@@ -1,0 +1,9 @@
+{{- if and .Values.esRollover.enabled .Values.esRollover.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jaeger.esRollover.serviceAccountName" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: es-index-rollover
+{{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -464,6 +464,8 @@ esIndexCleaner:
   pullPolicy: Always
   cmdlineParams: {}
   extraEnv: []
+    # - name: ROLLOVER
+    #   value: 'true'
   schedule: "55 23 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
@@ -475,6 +477,90 @@ esIndexCleaner:
     #   cpu: 256m
     #   memory: 128Mi
   numberOfDays: 7
+  serviceAccount:
+    create: true
+    name:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraSecretMounts: []
+  extraConfigmapMounts: []
+  podAnnotations: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+
+esRollover:
+  enabled: false
+  securityContext: {}
+  podSecurityContext:
+    runAsUser: 1000
+  annotations: {}
+  image: jaegertracing/jaeger-es-rollover
+  imagePullSecrets: []
+  tag: latest
+  pullPolicy: Always
+  cmdlineParams: {}
+  extraEnv:
+    - name: CONDITIONS
+      value: '{"max_age": "1d"}'
+  schedule: "10 0 * * *"
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 256m
+    #   memory: 128Mi
+  serviceAccount:
+    create: true
+    name:
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+  extraSecretMounts: []
+  extraConfigmapMounts: []
+  podAnnotations: {}
+  ## Additional pod labels
+  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  podLabels: {}
+  initHook:
+    extraEnv: []
+      # - name: SHARDS
+      #   value: "3"
+    annotations: {}
+    podAnnotations: {}
+    podLabels: {}
+    ttlSecondsAfterFinished: 120
+
+esLookback:
+  enabled: false
+  securityContext: {}
+  podSecurityContext:
+    runAsUser: 1000
+  annotations: {}
+  image: jaegertracing/jaeger-es-rollover
+  imagePullSecrets: []
+  tag: latest
+  pullPolicy: Always
+  cmdlineParams: {}
+  extraEnv:
+    - name: UNIT
+      value: days
+    - name: UNIT_COUNT
+      value: '7'
+  schedule: '5 0 * * *'
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 3
+  resources: {}
+    # limits:
+    #   cpu: 500m
+    #   memory: 512Mi
+    # requests:
+    #   cpu: 256m
+    #   memory: 128Mi
   serviceAccount:
     create: true
     name:


### PR DESCRIPTION
Signed-off-by: Vyacheslav Artemiev <v.artemiev@semrush.com>

#### What this PR does

Adds jobs to use the ES rollover feature https://www.jaegertracing.io/docs/1.19/deployment/#elasticsearch-rollover

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
