### PR TITLE
[jaeger] Fix ES rollover init job service account creation

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.19.2
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.38.1
+version: 0.38.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-rollover-sa.yaml
+++ b/charts/jaeger/templates/es-rollover-sa.yaml
@@ -6,4 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: es-index-rollover
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    # Must be created before the rollover init hook
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation
 {{- end -}}


### PR DESCRIPTION
Signed-off-by: Vyacheslav Artemiev <v.artemiev@semrush.com>

#### Which issue this PR fixes
- Rollover init hook tries to use a service account that has not yet been created 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
