### PR TITLE
[jaeger-operator] Add missing space to export command

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.18.2
+version: 2.18.3
 appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/NOTES.txt
+++ b/charts/jaeger-operator/templates/NOTES.txt
@@ -2,7 +2,7 @@ jaeger-operator is installed.
 
 
 Check the jaeger-operator logs
-  export POD=$(kubectl get pods-l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
+  export POD=$(kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
   kubectl logs $POD --namespace={{ .Release.Namespace }}
 
 


### PR DESCRIPTION
#### What this PR does

Fix non-working export command in jaeger-operator `NOTES.txt`

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
