### PR TITLE
[jaeger] Add the option to enable ingress for the collector

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.1
+version: 0.39.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/requirements.yaml
+++ b/charts/jaeger/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
   - name: cassandra
-    version: ^0.15.0
+    version: 0.15.3
     repository: https://kubernetes-charts-incubator.storage.googleapis.com/
     condition: provisionDataStore.cassandra
   - name: elasticsearch

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.collector.ingress.enabled -}}
+{{- $servicePort := .Values.collector.service.http.port -}}
+{{- $basePath := .Values.collector.basePath -}}
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "jaeger.collector.name" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: collector
+  {{- if .Values.collector.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
+  {{- end }}
+spec:
+  rules:
+    {{- range $host := .Values.collector.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: {{ $basePath }}
+            backend:
+              serviceName: {{ template "jaeger.collector.name" $ }}
+              servicePort: {{ $servicePort }}
+    {{- end -}}
+  {{- if .Values.collector.ingress.tls }}
+  tls:
+    {{- toYaml .Values.collector.ingress.tls | nindent 4 }}
+  {{- end -}}
+{{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -279,6 +279,20 @@ collector:
     zipkin: {}
       # port: 9411
       # nodePort:
+  ingress:
+    enabled: false
+    annotations: {}
+    # Used to create an Ingress record.
+    # hosts:
+    #   - chart-example.local
+    # annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
   resources: {}
     # limits:
     #   cpu: 1


### PR DESCRIPTION
#### What this PR does

Add the option to enable ingress for the collector

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
