### PR TITLE
#176 -[jaeger] Remove recreate deployment strategy from deployment templates …

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: 1.20.1
+appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.2
+version: 0.39.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
-appVersion: 1.20.0
+appVersion: 1.20.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 version: 0.39.2

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -18,8 +18,6 @@ spec:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: collector
-  strategy:
-    type: Recreate
   template:
     metadata:
       annotations:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -18,8 +18,6 @@ spec:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: ingester
-  strategy:
-    type: Recreate
   template:
     metadata:
       annotations:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -16,8 +16,6 @@ spec:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: query
-  strategy:
-    type: Recreate
   template:
     metadata:
 {{- if .Values.query.podAnnotations }}


### PR DESCRIPTION
…to default to rolling updates

Signed-off-by: santosh <bsantosh@thoughtworks.com>

#### What this PR does
Removes deployment strategy from deployment templates to default to rolling updates
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #176

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
