### PR TITLE
[jaeger] add option to configure service account annotations

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.3
+version: 0.39.4
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-sa.yaml
+++ b/charts/jaeger/templates/agent-sa.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
+  {{- with .Values.agent.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/collector-sa.yaml
+++ b/charts/jaeger/templates/collector-sa.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
+  {{- with .Values.collector.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/query-sa.yaml
+++ b/charts/jaeger/templates/query-sa.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: query
+  {{- with .Values.query.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -219,6 +219,7 @@ agent:
   serviceAccount:
     create: true
     name:
+    annotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -303,6 +304,7 @@ collector:
   serviceAccount:
     create: true
     name:
+    annotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}
@@ -404,6 +406,7 @@ query:
   serviceAccount:
     create: true
     name:
+    annotations: {}
   nodeSelector: {}
   tolerations: []
   affinity: {}


### PR DESCRIPTION
Adds ability to configure service account annotations for query, collector and agent. This can allow for example configure AWS IAM roles for service accounts.

#### What this PR does

Adds option to configure service account annotations for query, collector and agent.

#### Which issue this PR fixes

- fixes #179 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
