### PR TITLE
[jaeger] Add concurrencyPolicy to CronJob and maxUnavailable to jaeger-agent daemonset

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.4
+version: 0.39.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -15,6 +15,10 @@ spec:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}
       app.kubernetes.io/component: agent
+  {{- with .Values.agent.daemonset.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   template:
     metadata:
 {{- if .Values.agent.podAnnotations }}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml .Values.esIndexCleaner.annotations | nindent 4 }}
 {{- end }}
 spec:
-  concurrencyPolicy: "Forbid"
+  concurrencyPolicy: {{ .Values.esIndexCleaner.concurrencyPolicy }}
   schedule: {{ .Values.esIndexCleaner.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.esIndexCleaner.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.esIndexCleaner.failedJobsHistoryLimit }}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml .Values.esLookback.annotations | nindent 4 }}
 {{- end }}
 spec:
-  concurrencyPolicy: "Forbid"
+  concurrencyPolicy: {{ .Values.esLookback.concurrencyPolicy }}
   schedule: {{ .Values.esLookback.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.esLookback.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.esLookback.failedJobsHistoryLimit }}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- toYaml .Values.esRollover.annotations | nindent 4 }}
 {{- end }}
 spec:
-  concurrencyPolicy: "Forbid"
+  concurrencyPolicy: {{ .Values.esRollover.concurrencyPolicy }}
   schedule: {{ .Values.esRollover.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.esRollover.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.esRollover.failedJobsHistoryLimit }}

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -14,6 +14,7 @@ spec:
   schedule: {{ .Values.spark.schedule | quote }}
   successfulJobsHistoryLimit: {{ .Values.spark.successfulJobsHistoryLimit }}
   failedJobsHistoryLimit: {{ .Values.spark.failedJobsHistoryLimit }}
+  concurrencyPolicy: {{ .Values.spark.concurrencyPolicy }}
   jobTemplate:
     spec:
       template:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -196,6 +196,10 @@ agent:
   extraEnv: []
   daemonset:
     useHostPort: false
+    updateStrategy:
+      type: RollingUpdate
+      rollingUpdate:
+        maxUnavailable: 1
   service:
     annotations: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)
@@ -449,6 +453,7 @@ spark:
   schedule: "49 23 * * *"
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
+  concurrencyPolicy: Forbid
   resources: {}
     # limits:
     #   cpu: 500m
@@ -486,6 +491,7 @@ esIndexCleaner:
   schedule: "55 23 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
   resources: {}
     # limits:
     #   cpu: 500m
@@ -524,6 +530,7 @@ esRollover:
   schedule: "10 0 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
   resources: {}
     # limits:
     #   cpu: 500m
@@ -571,6 +578,7 @@ esLookback:
   schedule: '5 0 * * *'
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
+  concurrencyPolicy: Forbid
   resources: {}
     # limits:
     #   cpu: 500m


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does

- It adds concurrencyPolicy to all cronjob templates, so users can set them as they see fit. Kept the default value "Forbid" for backwards compatibility.
- Added Max Unavailable value to Jaeger agent daemonset (its default 1 and i kept it 1 in the values.yaml file).

#### Which issue this PR fixes

- fixes #128 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
