### PR TITLE
[jaeger] Make default value for daemonset updateStrategy an empty map {}

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.5
+version: 0.39.6
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -196,10 +196,10 @@ agent:
   extraEnv: []
   daemonset:
     useHostPort: false
-    updateStrategy:
-      type: RollingUpdate
-      rollingUpdate:
-        maxUnavailable: 1
+    updateStrategy: {}
+      # type: RollingUpdate
+      # rollingUpdate:
+      #   maxUnavailable: 1
   service:
     annotations: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does
- Sets default value for updateStrategy of the agent daemonset.

#### Which issue this PR fixes

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
