### PR TITLE
[jaeger] Fixes elasticsearch jobs extraSecretMounts reference and secret resource creation.

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.6
+version: 0.39.7
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/elasticsearch-secret.yaml
+++ b/charts/jaeger/templates/elasticsearch-secret.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "jaeger.fullname" . }}-elasticsearch
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
 type: Opaque
 data:
   password: {{ .Values.storage.elasticsearch.password | b64enc | quote }}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -80,4 +80,15 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+          volumes:
+          {{- range .Values.esIndexCleaner.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esIndexCleaner.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -81,4 +81,15 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+          volumes:
+          {{- range .Values.esLookback.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esLookback.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -81,4 +81,15 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+          volumes:
+          {{- range .Values.esRollover.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esRollover.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -72,4 +72,15 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+      volumes:
+      {{- range .Values.esRollover.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
+      {{- range .Values.esRollover.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
 {{- end -}}


### PR DESCRIPTION
#### What this PR does
This Pr is aimed at solving a couple of issues I encountered when installing jaeger elasticsearch jobs with a tls certificate mounted secret.
What happened before the PR was:

- extraSecretMounts in all elasticsearch cronjobs and rollover init hook were referenced as `volumeMounts` but not as `volumes`, leading to helm failing with errors like: `Job.batch "jaeger-store-es-rollover-init" is invalid: spec.template.spec.containers[0].volumeMounts[0].name: Not found: "jaeger-tls"` 
- the elasticsearch secret resource was created after the `es-rollover-init` job hook, hence causing it to hang while looking for that secret. ` Error: secret "jaeger-store-elasticsearch" not found`

Remediation was to:
- add the `volumes` field in all the cronjob and job resources with reference to extraSecretMounts. 
- annotate the elasticsearch secret as a pre-install hook as well, with a weight of -1 so that it would be installed before the `es-rollover-init` job.
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
