### PR TITLE
[jaeger] add query healthcheck

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.7
+version: 0.39.8
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -22,6 +22,12 @@ spec:
             backend:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}
+    {{- if .Values.query.ingress.healthCheckEnabled }}
+          - path: /health
+            backend:
+              serviceName: {{ template "jaeger.query.name" $ }}
+              servicePort: 16687
+    {{- end -}}                
     {{- end -}}
   {{- if .Values.query.ingress.tls }}
   tls:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -298,6 +298,7 @@ collector:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+    # healthCheckEnabled: true
   resources: {}
     # limits:
     #   cpu: 1


### PR DESCRIPTION
#### What this PR does
Adds healthcheck to query ingress for external endpoint based monitoring e.g. pingdom or statuscake

#### Which issue this PR fixes

Solves this via chart instead of code: 
- https://github.com/jaegertracing/jaeger-ui/issues/671

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
