### PR TITLE
[jaeger] add query healthcheck

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.18.2
+version: 2.18.3
 appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.18.1
+version: 2.18.2
 appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,11 +1,12 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.18.0
+version: 2.18.1
 appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
-source: https://github.com/jaegertracing/jaeger-operator
+sources:
+  - https://github.com/jaegertracing/jaeger-operator
 maintainers:
   - email: ctadeu@gmail.com
     name: cpanato

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.17.0
-appVersion: 1.19.0
+version: 2.18.0
+appVersion: 1.20.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 source: https://github.com/jaegertracing/jaeger-operator

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | Parameter               | Description                                                                                                 | Default                         |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.19.0`                        |
+| `image.tag`             | Controller container image tag                                                                              | `1.20.0`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -14,7 +14,7 @@ This chart bootstraps a jaeger-operator deployment on a [Kubernetes](http://kube
 
 ## Prerequisites
 
-- Kubernetes 1.8+ with Beta APIs enabled
+- Kubernetes 1.16+
 
 ## Installing the Chart
 

--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.jaegertracing.io
@@ -31,3 +31,7 @@ spec:
     - name: v1
       served: true
       storage: true
+      schema:
+        openAPIV3Schema:
+          type: object
+          x-kubernetes-preserve-unknown-fields: true

--- a/charts/jaeger-operator/templates/NOTES.txt
+++ b/charts/jaeger-operator/templates/NOTES.txt
@@ -2,7 +2,7 @@ jaeger-operator is installed.
 
 
 Check the jaeger-operator logs
-  export POD=$(kubectl get pods-l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
+  export POD=$(kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
   kubectl logs $POD --namespace={{ .Release.Namespace }}
 
 

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -3,7 +3,7 @@
 # Declare variables to be passed into your templates.
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.19.0
+  tag: 1.20.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.6
+version: 0.39.7
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.7
+version: 0.39.8
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/elasticsearch-secret.yaml
+++ b/charts/jaeger/templates/elasticsearch-secret.yaml
@@ -5,6 +5,11 @@ metadata:
   name: {{ include "jaeger.fullname" . }}-elasticsearch
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": pre-install,pre-upgrade
+    "helm.sh/hook-weight": "-1"
+    "helm.sh/hook-delete-policy": before-hook-creation
+    "helm.sh/resource-policy": keep
 type: Opaque
 data:
   password: {{ .Values.storage.elasticsearch.password | b64enc | quote }}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -80,4 +80,15 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+          volumes:
+          {{- range .Values.esIndexCleaner.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esIndexCleaner.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -81,4 +81,15 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+          volumes:
+          {{- range .Values.esLookback.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esLookback.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -81,4 +81,15 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+          volumes:
+          {{- range .Values.esRollover.extraConfigmapMounts }}
+            - name: {{ .name }}
+              configMap:
+                name: {{ .configMap }}
+          {{- end }}
+          {{- range .Values.esRollover.extraSecretMounts }}
+            - name: {{ .name }}
+              secret:
+                secretName: {{ .secretName }}
+        {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -72,4 +72,15 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+      volumes:
+      {{- range .Values.esRollover.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
+      {{- range .Values.esRollover.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -23,6 +23,12 @@ spec:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}
     {{- end -}}
+    {{- if .Values.query.ingress.healthCheckEnabled }}
+          - path: /health
+            backend:
+              serviceName: {{ template "jaeger.query.name" $ }}
+              servicePort: 16687
+    {{- end -}}
   {{- if .Values.query.ingress.tls }}
   tls:
     {{- toYaml .Values.query.ingress.tls | nindent 4 }}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -23,7 +23,7 @@ spec:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}
     {{- end -}}
-    {{- if .Values.query.ingress.healthCheckEnabled }}
+    {{- if .Values.query.ingress.health.exposed }}
           - path: /health
             backend:
               serviceName: {{ template "jaeger.query.name" $ }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -298,6 +298,7 @@ collector:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+      # healthCheckEnabled: true
   resources: {}
     # limits:
     #   cpu: 1

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -298,7 +298,8 @@ collector:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
-      # healthCheckEnabled: true
+      health
+        exposed: false
   resources: {}
     # limits:
     #   cpu: 1

--- a/ct.yaml
+++ b/ct.yaml
@@ -3,7 +3,7 @@ remote: origin
 chart-dirs:
   - charts
 chart-repos:
-  - incubator=https://kubernetes-charts-incubator.storage.googleapis.com
+  - incubator=https://charts.helm.sh/incubator
   - elastic=https://helm.elastic.co
   - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout=600s


### PR DESCRIPTION
Signed-off-by: sharkymcdongles <bryanfcarmichael@gmail.com>

#### What this PR does

Adds healthcheck for endpoint-based monitoring like statuscake or pingdom.

#### Which issue this PR fixes

- https://github.com/jaegertracing/jaeger-ui/issues/671

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
