### PR TITLE
[jaeger] add health check to ingress

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.20.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.39.7
+version: 0.39.8
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -23,6 +23,12 @@ spec:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}
     {{- end -}}
+    {{- if .Values.query.ingress.health.exposed }}
+          - path: /health
+            backend:
+              serviceName: {{ template "jaeger.query.name" $ }}
+              servicePort: 16687
+    {{- end -}}    
   {{- if .Values.query.ingress.tls }}
   tls:
     {{- toYaml .Values.query.ingress.tls | nindent 4 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -400,6 +400,8 @@ query:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+    health:
+      exposed: false
   resources: {}
     # limits:
     #   cpu: 500m


### PR DESCRIPTION
#### What this PR does
Adds configurable healthcheck to ingress

#### Which issue this PR fixes

https://github.com/jaegertracing/jaeger-ui/issues/671

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
