### PR TITLE
[jaeger] Adds ability to set enableServiceLinks to false

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.21.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.40.0
+version: 0.40.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -46,6 +46,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      enableServiceLinks: {{ .Values.agent.enableServiceLinks }}
       containers:
       - name: {{ template "jaeger.agent.name" . }}
         securityContext:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -201,7 +201,7 @@ agent:
       # rollingUpdate:
       #   maxUnavailable: 1
   # Set to false if your release is called `jaeger`.
-  # Read More: https://github.com/jaegertracing/jaeger/issues/1986 
+  # Read More: https://github.com/jaegertracing/jaeger/issues/1986
   enableServiceLinks: true
   service:
     annotations: {}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -200,8 +200,6 @@ agent:
       # type: RollingUpdate
       # rollingUpdate:
       #   maxUnavailable: 1
-  # Set to false if your release is called `jaeger`.
-  # Read More: https://github.com/jaegertracing/jaeger/issues/1986
   enableServiceLinks: true
   service:
     annotations: {}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -200,6 +200,9 @@ agent:
       # type: RollingUpdate
       # rollingUpdate:
       #   maxUnavailable: 1
+  # Set to false if your release is called `jaeger`.
+  # Read More: https://github.com/jaegertracing/jaeger/issues/1986 
+  enableServiceLinks: true
   service:
     annotations: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)


### PR DESCRIPTION
#### What this PR does
Attempt to fix: https://github.com/jaegertracing/jaeger/issues/1986 and https://github.com/prometheus/prometheus/issues/7286

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
