### PR TITLE
[jaeger-operator]: fix invalid crd.yaml to conform to apiextensions.k8s.io/v1 CustomResourceDefinition schema

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.19.0
+version: 2.19.1
 appVersion: 1.21.2
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -8,15 +8,6 @@ metadata:
   labels:
     app: jaeger-operator
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.phase
-    description: Jaeger instance's status
-    name: Status
-    type: string
-  - JSONPath: .status.version
-    description: Jaeger Version
-    name: Version
-    type: string
   group: jaegertracing.io
   names:
     kind: Jaeger
@@ -24,9 +15,6 @@ spec:
     plural: jaegers
     singular: jaeger
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1
   versions:
     - name: v1
       served: true
@@ -35,3 +23,12 @@ spec:
         openAPIV3Schema:
           type: object
           x-kubernetes-preserve-unknown-fields: true
+      additionalPrinterColumns:
+        - jsonPath: .status.phase
+          description: Jaeger instance's status
+          name: Status
+          type: string
+        - jsonPath: .status.version
+          description: Jaeger Version
+          name: Version
+          type: string


### PR DESCRIPTION
#### What this PR does
This PRs fixes an issue which caused an error when installing the jaeger-operator chart due to an invalid CRD yaml.  

#### Which issue this PR fixes
- fixes #193

I did test deployments to GKE 1.18.12-gke.1210 and K3D versions v1.16.15-k3s1, v1.18.15-k3s1, v1.20.2-k3s1.

#### Checklist
- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
