### PR TITLE
[jaeger] Add activeDeadlineSeconds field to Job template for the spark job

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ will close that issue when PR gets merged)*
 
 #### Checklist
 
-- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
+- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/master/CONTRIBUTING.md#sign-off-your-work) signed
 - [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
 - [ ] Chart Version bumped
 - [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 1.21.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
-version: 0.40.1
+version: 0.40.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -17,6 +17,9 @@ spec:
   concurrencyPolicy: {{ .Values.spark.concurrencyPolicy }}
   jobTemplate:
     spec:
+      {{- if .Values.spark.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.spark.activeDeadlineSeconds }}
+      {{- end}}
       template:
         metadata:
           labels:


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does

- Adds a `activeDeadlineSeconds` field to the Job template for the spark cronjob. This would help, if someone wants the job to terminate after X number of seconds.
https://kubernetes.io/docs/concepts/workloads/controllers/job/#job-termination-and-cleanup
- Also Fixed DCO link to CONTRIBUTING.md

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
