### PR TITLE
[jaeger] update to 1.22.0

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -14,35 +14,34 @@ jobs:
       - name: Set up Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.4.1
 
-      - name: Add dependency chart repos
-        run: |
-          helm repo add incubator https://charts.helm.sh/incubator
-          helm repo add elastic https://helm.elastic.co
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-
-      - uses: actions/setup-python@v2
+      # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+      # yamllint (https://github.com/adrienverge/yamllint) which require Python
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
           python-version: 3.7
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.0.1
+        with:
+          version: v3.3.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
         run: |
-          changed=$(ct list-changed)
+          changed=$(ct list-changed --config ct.yaml)
           if [[ -n "$changed" ]]; then
             echo "::set-output name=changed::true"
           fi
 
       - name: Run chart-testing (lint)
-        run: ct lint
+        run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0
+        uses: helm/kind-action@v1.1.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)
-        run: ct install
+        run: ct install --config ct.yaml

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Helm
         uses: azure/setup-helm@v1
         with:
-          version: v3.4.0
+          version: v3.4.1
 
       - name: Add dependency chart repos
         run: |

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.21.0
+appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.41.0
+version: 0.42.0
 keywords:
   - jaeger
   - opentracing
@@ -30,7 +30,7 @@ dependencies:
     repository: https://charts.helm.sh/incubator
     condition: provisionDataStore.cassandra
   - name: elasticsearch
-    version: ^7.5.1
+    version: ^7.11.1
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -7,7 +7,7 @@ provisionDataStore:
   elasticsearch: false
   kafka: false
 
-tag: 1.21.0
+tag: 1.22.0
 
 nameOverride: ""
 fullnameOverride: ""

--- a/ct.yaml
+++ b/ct.yaml
@@ -7,3 +7,4 @@ chart-repos:
   - elastic=https://helm.elastic.co
   - bitnami=https://charts.bitnami.com/bitnami
 helm-extra-args: --timeout=600s
+target-branch: main


### PR DESCRIPTION

#### What this PR does

update jaeger to 1.22.0
also update elasticsearch subchart to latest 7.x



#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
