### PR TITLE
[jaeger] Update deprecated COLLECTOR_ZIPKIN_HTTP_PORT variable

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.42.0
+version: 0.42.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -61,7 +61,7 @@ spec:
           {{- end }}
         env:
           {{- if .Values.collector.service.zipkin }}
-          - name: COLLECTOR_ZIPKIN_HTTP_PORT
+          - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: {{ .Values.collector.service.zipkin.port | quote }}
           {{- end }}
           {{- if .Values.ingester.enabled }}


### PR DESCRIPTION
Signed-off-by: Kristián Patlevič <patlevic.kristian@gmail.com>

#### What this PR does
Based on the change in the version [1.22.0](Remove deprecated CLI flags (#2751, @LostLaser)) it's changing the deprecated `COLLECTOR_ZIPKIN_HTTP_PORT` variable to new `COLLECTOR_ZIPKIN_HOST_PORT`. 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
