### PR TITLE
[jaeger] Add serviceAccountName to ingester deploy

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.42.1
+version: 0.42.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -31,6 +31,7 @@ spec:
         {{- toYaml .Values.ingester.podLabels | nindent 8 }}
 {{- end }}
     spec:
+      serviceAccountName: {{ include "jaeger.ingester.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.ingester.podSecurityContext | nindent 8 }}
       {{- with .Values.ingester.imagePullSecrets }}


### PR DESCRIPTION
Signed-off-by: Chirag Tailor <ctailor2@gmail.com>

#### What this PR does

This adds serviceAccountName to the ingester deploy to ensure that pods managed by the deployment are associated with the service account that is either specified by the user or created by the helm chart.

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
