### PR TITLE
[jaeger] Allow installing extra objects along with the chart

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.42.2
+version: 0.43.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -263,3 +263,26 @@ helm install jaeger jaegertracing/jaeger \
   --set storage.kafka.brokers={<BROKER1:PORT>,<BROKER2:PORT>} \
   --set storage.kafka.topic=<TOPIC>
 ```
+
+## Installing extra kubernetes objects
+
+If additional kubernetes objects need to be installed alongside this chart, set the `extraObjects` array to contain 
+the yaml describing these objects. The values in the array are treated as a template to allow the use of variable 
+substitution and function calls as in the example below.
+
+Content of the `jaeger-values.yaml` file:
+
+```YAML
+extraObjects:
+  - apiVersion: rbac.authorization.k8s.io/v1
+    kind: RoleBinding
+    metadata:
+      name: {{ .Release.Name }}-someRoleBinding
+    roleRef:
+      apiGroup: rbac.authorization.k8s.io
+      kind: Role
+      name: someRole
+    subjects:
+      - kind: ServiceAccount
+        name: "{{ include \"jaeger.esLookback.serviceAccountName\" . }}"
+```

--- a/charts/jaeger/templates/extra-list.yaml
+++ b/charts/jaeger/templates/extra-list.yaml
@@ -1,0 +1,4 @@
+{{- range .Values.extraObjects }}
+---
+{{ tpl (. | toYaml) $ }}
+{{- end }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -651,3 +651,6 @@ hotrod:
   tracing:
     host: null
     port: 6831
+
+# Array with extra yaml objects to install alongside the chart. Values are evaluated as a template.
+extraObjects: []


### PR DESCRIPTION
#### What this PR does

This allows users to install extra kubernetes objects alongside this chart in the same fashion that many of the bitnami charts offer this capability. See the following bitnami charts for reference:

https://github.com/bitnami/charts/blob/master/bitnami/cassandra/values.yaml#L565
https://github.com/bitnami/charts/blob/master/bitnami/mariadb/values.yaml#L870

I would like this capability to exist in the jaeger helm chart to make it easier to manage pod security policies for the jaeger components as they are installed in my cluster.

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
