### PR TITLE
[jaeger] Allow template strings in kafka brokers value

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.43.0
+version: 0.43.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -75,7 +75,7 @@ spec:
           {{- toYaml .Values.storage.kafka.extraEnv | nindent 10 }}
         {{- end }}
           - name: KAFKA_PRODUCER_BROKERS
-            value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers }}
+            value: {{ tpl (include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers) . }}
           - name: KAFKA_PRODUCER_TOPIC
             value: {{ .Values.storage.kafka.topic }}
           - name: KAFKA_PRODUCER_AUTHENTICATION

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -67,7 +67,7 @@ spec:
             value: {{ .Values.storage.type }}
           {{- include "storage.env" . | nindent 10 }}
           - name: KAFKA_CONSUMER_BROKERS
-            value: {{ include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers }}
+            value: {{ tpl (include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers) . }}
           - name: KAFKA_CONSUMER_TOPIC
             value: {{ .Values.storage.kafka.topic }}
           - name: KAFKA_CONSUMER_AUTHENTICATION


### PR DESCRIPTION
#### What this PR does

Pass `.Values.storage.kafka.brokers` through the `tpl` function in both usages to process the value as a template. Allowing template strings here makes it possible for users that provision kafka as part of the jaeger deployment to configure this value in the values yaml file rather than requiring it to be set via a flag. For installs that provision kafka without name overrides, the following template string should generally work here.

```yaml
storage:
  kafka:
    brokers:
      - "{{ .Release.Name }}-kafka"
```

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
