### PR TITLE
[Jaeger] Make .Values.tag default to .Chart.AppVersion

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.43.1
+version: 0.43.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -32,6 +32,13 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
+Create image tag value which defaults to .Chart.AppVersion.
+*/}}
+{{- define "jaeger.image.tag" -}}
+{{- .Values.tag | default .Chart.AppVersion }}
+{{- end -}}
+
+{{/*
 Common labels
 */}}
 {{- define "jaeger.labels" -}}

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -50,7 +50,7 @@ spec:
       - name: {{ template "jaeger.agent.name" . }}
         securityContext:
           {{- toYaml .Values.agent.securityContext | nindent 10 }}
-        image: {{ .Values.agent.image }}:{{ .Values.tag }}
+        image: {{ .Values.agent.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:
           {{- range $key, $value := .Values.agent.cmdlineParams }}

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -34,7 +34,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-cassandra-schema
-        image: {{ .Values.schema.image }}:{{ .Values.tag }}
+        image: {{ .Values.schema.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
         securityContext:
           {{- toYaml .Values.schema.securityContext | nindent 10 }}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -46,7 +46,7 @@ spec:
       - name: {{ template "jaeger.collector.name" . }}
         securityContext:
           {{- toYaml .Values.collector.securityContext | nindent 10 }}
-        image: {{ .Values.collector.image }}:{{ .Values.tag }}
+        image: {{ .Values.collector.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         args:
           {{- range $key, $value := .Values.collector.cmdlineParams -}}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -42,7 +42,7 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-es-index-cleaner
             securityContext:
               {{- toYaml .Values.esIndexCleaner.securityContext | nindent 14 }}
-            image: "{{ .Values.esIndexCleaner.image }}:{{ .Values.esIndexCleaner.tag }}"
+            image: "{{ .Values.esIndexCleaner.image }}:{{- include "jaeger.image.tag" . }}"
             imagePullPolicy: {{ .Values.esIndexCleaner.pullPolicy }}
             args:
               - {{ .Values.esIndexCleaner.numberOfDays | quote }}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -56,7 +56,7 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-es-lookback
             securityContext:
               {{- toYaml .Values.esLookback.securityContext | nindent 14 }}
-            image: "{{ .Values.esLookback.image }}:{{ .Values.esLookback.tag }}"
+            image: "{{ .Values.esLookback.image }}:{{- include "jaeger.image.tag" . }}"
             imagePullPolicy: {{ .Values.esLookback.pullPolicy }}
             args:
               - lookback

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -56,7 +56,7 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-es-rollover
             securityContext:
               {{- toYaml .Values.esRollover.securityContext | nindent 14 }}
-            image: "{{ .Values.esRollover.image }}:{{ .Values.esRollover.tag }}"
+            image: "{{ .Values.esRollover.image }}:{{- include "jaeger.image.tag" . }}"
             imagePullPolicy: {{ .Values.esRollover.pullPolicy }}
             args:
               - rollover

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -29,7 +29,7 @@ spec:
         - name: {{ include "jaeger.fullname" . }}-hotrod
           securityContext:
             {{- toYaml .Values.hotrod.securityContext | nindent 12 }}
-          image: {{ .Values.hotrod.image.repository }}:{{ .Values.tag }}
+          image: {{ .Values.hotrod.image.repository }}:{{- include "jaeger.image.tag" . }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
           env:
             - name: JAEGER_AGENT_HOST

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -48,7 +48,7 @@ spec:
       - name: {{ include "jaeger.fullname" . }}-ingester
         securityContext:
           {{- toYaml .Values.ingester.securityContext | nindent 10 }}
-        image: {{ .Values.ingester.image }}:{{ .Values.tag }}
+        image: {{ .Values.ingester.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
         args:
           {{- range $key, $value := .Values.ingester.cmdlineParams }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -43,7 +43,7 @@ spec:
       - name: {{ template "jaeger.query.name" . }}
         securityContext:
           {{- toYaml .Values.query.securityContext | nindent 10 }}
-        image: {{ .Values.query.image }}:{{ .Values.tag }}
+        image: {{ .Values.query.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         args:
           {{- range $key, $value := .Values.query.cmdlineParams }}
@@ -123,7 +123,7 @@ spec:
       - name: {{ template "jaeger.agent.name" . }}-sidecar
         securityContext:
           {{- toYaml .Values.query.securityContext | nindent 10 }}
-        image: {{ .Values.agent.image }}:{{ .Values.tag }}
+        image: {{ .Values.agent.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:
           {{- range $key, $value := .Values.agent.cmdlineParams }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -7,7 +7,8 @@ provisionDataStore:
   elasticsearch: false
   kafka: false
 
-tag: 1.22.0
+# Overrides the image tag where default is the chart appVersion.
+tag: ""
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Created a new Template variable that is used instead of `.Values.tag` in chart template files and it defaults to
`.Chart.AppVersion`

Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does
Makes a new helper template variable that is used for image tag in all template files. Default for that tag value is chart.appVersion (or it can be overridden by the users of the chart).

#### Which issue this PR fixes

- fixes #185 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
