### PR TITLE
Cleanup spark-cronjob storage env vars

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.43.2
+version: 0.43.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -53,12 +53,16 @@ spec:
             {{- if .Values.spark.extraEnv }}
               {{- toYaml .Values.spark.extraEnv | nindent 14 }}
             {{- end }}
+            {{- if eq .Values.storage.type "cassandra" }}
               - name: CASSANDRA_CONTACT_POINTS
                 value: {{ include "cassandra.contact_points" . }}
+            {{- end }}
+            {{- if eq .Values.storage.type "elasticsearch" }}
               - name: ES_NODES
                 value: {{ include "elasticsearch.client.url" . }}
               - name: ES_NODES_WAN_ONLY
                 value: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
+            {{- end }}
             resources:
               {{- toYaml .Values.spark.resources | nindent 14 }}
             volumeMounts:


### PR DESCRIPTION
When setting storage type to Elasticsearch, the Cassandra env variable is generated while unneeded (+ the other way around). 

```
    Environment:
      STORAGE:                   elasticsearch
      ES_SERVER_URLS:            https://elasticsearch.<hidden>:9200
      ES_USERNAME:               elastic
      ES_PASSWORD:               <set to the key 'password' in secret 'jaeger-elasticsearch'>  Optional: false
      CASSANDRA_CONTACT_POINTS:  cassandra:9042
      ES_NODES:                  https://elasticsearch.<hidden>:9200
      ES_NODES_WAN_ONLY:         true
```

This PR fixes that.