### PR TITLE
[jaeger-operator] Adding support for NodePort in Jaeger Operator Helm Chart

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.19.1
+version: 2.20.0
 appVersion: 1.21.2
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -14,4 +14,7 @@ spec:
   selector:
     app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  type: ClusterIP
+  type: {{ .Values.service.type }}
+    {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) -}}
+    nodePort: {{ .Values.service.nodePort }}
+  {{- end -}}

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -11,10 +11,10 @@ spec:
     port: 8383
     protocol: TCP
     targetPort: 8383
+{{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
+    nodePort: {{ .Values.service.nodePort }}
+{{- end }}
   selector:
     app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   type: {{ .Values.service.type }}
-    {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) -}}
-    nodePort: {{ .Values.service.nodePort }}
-  {{- end -}}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -23,6 +23,11 @@ rbac:
   pspEnabled: false
   clusterRole: false
 
+service:
+  type: ClusterIP
+  # Specify a specific node port when type is NodePort
+    # nodePort: 32500
+
 serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: true

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -1,6 +1,7 @@
 # Default values for jaeger-operator.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
+
 image:
   repository: jaegertracing/jaeger-operator
   tag: 1.21.2
@@ -26,7 +27,7 @@ rbac:
 service:
   type: ClusterIP
   # Specify a specific node port when type is NodePort
-    # nodePort: 32500
+  # nodePort: 32500
 
 serviceAccount:
   # Specifies whether a ServiceAccount should be created


### PR DESCRIPTION
Signed-off-by: GitHub <noreply@github.com>

#### What this PR does
Adds support for NodePort in the Jaeger Operator

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes # https://github.com/jaegertracing/helm-charts/issues/229

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
