### PR TITLE
[Jaeger] Add "automountServiceAccountToken" field to the serviceAccount Templates

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.44.0
+version: 0.44.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-sa.yaml
+++ b/charts/jaeger/templates/agent-sa.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.agent.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/cassandra-schema-sa.yaml
+++ b/charts/jaeger/templates/cassandra-schema-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: cassandra-schema
+automountServiceAccountToken: {{ .Values.schema.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/collector-sa.yaml
+++ b/charts/jaeger/templates/collector-sa.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.collector.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/es-index-cleaner-sa.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: es-index-cleaner
+automountServiceAccountToken: {{ .Values.esIndexCleaner.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-sa.yaml
+++ b/charts/jaeger/templates/es-lookback-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: es-lookback
+automountServiceAccountToken: {{ .Values.esLookback.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-sa.yaml
+++ b/charts/jaeger/templates/es-rollover-sa.yaml
@@ -11,4 +11,5 @@ metadata:
     # Must be created before the rollover init hook
     "helm.sh/hook-weight": "-10"
     "helm.sh/hook-delete-policy": before-hook-creation
+automountServiceAccountToken: {{ .Values.esRollover.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/hotrod-sa.yaml
+++ b/charts/jaeger/templates/hotrod-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: hotrod
+automountServiceAccountToken: {{ .Values.hotrod.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/ingester-sa.yaml
+++ b/charts/jaeger/templates/ingester-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingester
+automountServiceAccountToken: {{ .Values.ingester.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/query-sa.yaml
+++ b/charts/jaeger/templates/query-sa.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.query.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/spark-sa.yaml
+++ b/charts/jaeger/templates/spark-sa.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: spark
+automountServiceAccountToken: {{ .Values.spark.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -120,6 +120,8 @@ schema:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   podAnnotations: {}
   podLabels: {}
@@ -170,6 +172,8 @@ ingester:
     #   memory: 512Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []
@@ -223,6 +227,8 @@ agent:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
     annotations: {}
   nodeSelector: {}
@@ -308,6 +314,8 @@ collector:
     #   memory: 512Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
     annotations: {}
   nodeSelector: {}
@@ -420,6 +428,8 @@ query:
     #    memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
     annotations: {}
   nodeSelector: {}
@@ -474,6 +484,8 @@ spark:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []
@@ -513,6 +525,8 @@ esIndexCleaner:
   numberOfDays: 7
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []
@@ -551,6 +565,8 @@ esRollover:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []
@@ -599,6 +615,8 @@ esLookback:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []
@@ -653,6 +671,8 @@ hotrod:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    # Explicitly mounts the API credentials for the Service Account
+    automountServiceAccountToken: true
     name:
   nodeSelector: {}
   tolerations: []

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -173,7 +173,7 @@ ingester:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []
@@ -228,7 +228,7 @@ agent:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
     annotations: {}
   nodeSelector: {}
@@ -315,7 +315,7 @@ collector:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
     annotations: {}
   nodeSelector: {}
@@ -429,7 +429,7 @@ query:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
     annotations: {}
   nodeSelector: {}
@@ -485,7 +485,7 @@ spark:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []
@@ -526,7 +526,7 @@ esIndexCleaner:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []
@@ -566,7 +566,7 @@ esRollover:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []
@@ -616,7 +616,7 @@ esLookback:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []
@@ -672,7 +672,7 @@ hotrod:
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
-    automountServiceAccountToken: true
+    automountServiceAccountToken: false
     name:
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does
Allows one to set `automountServiceAccountToken` on the serviceAccounts created by the upstream chart.
https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server

#### Which issue this PR fixes
N/A

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
