### PR TITLE
[jaeger] Adding proxy sidecar to the jaeger-query pod 

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.43.3
+version: 0.44.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -119,6 +119,39 @@ spec:
           httpGet:
             path: /
             port: admin
+{{- if .Values.query.oAuthSidecar.enabled }}
+      - name: {{ template "jaeger.agent.name" . }}-oauth2-sidecar
+        image: {{ .Values.query.oAuthSidecar.image }}
+        imagePullPolicy: {{ .Values.query.oAuthSidecar.pullPolicy }}
+        args:
+        {{- range .Values.query.oAuthSidecar.args }}
+          - {{ . }}
+        {{- end }}
+        volumeMounts:
+        {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
+            subPath: {{ .subPath }}
+            readOnly: {{ .readOnly }}
+        {{- end }}
+        {{- range .Values.query.oAuthSidecar.extraSecretMounts }}
+          - name: {{ .name }}
+            mountPath: {{ .mountPath }}
+            subPath: {{ .subPath }}
+            readOnly: {{ .readOnly }}
+        {{- end }}
+        ports:
+          - containerPort: {{ .Values.query.oAuthSidecar.containerPort }}
+            name: oauth-proxy
+        {{- if .Values.query.oAuthSidecar.livenessProbe }}
+        livenessProbe:
+          {{- toYaml .Values.query.oAuthSidecar.livenessProbe | nindent 10 }}
+        {{- end }}
+        {{- if .Values.query.oAuthSidecar.readinessProbe }}
+        readinessProbe:
+          {{- toYaml .Values.query.oAuthSidecar.readinessProbe | nindent 10 }}
+        {{- end }}
+{{- end }}
 {{- if .Values.query.agentSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-sidecar
         securityContext:
@@ -182,6 +215,18 @@ spec:
           configMap:
             name: {{ include "jaeger.fullname" . }}-ui-configuration
       {{- end }}
+{{- if .Values.query.oAuthSidecar.enabled }}
+      {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}
+        - name: {{ .name }}
+          configMap:
+            name: {{ .configMap }}
+      {{- end }}
+      {{- range .Values.query.oAuthSidecar.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
+      {{- end }}
+{{- end }}
 {{- if .Values.query.agentSidecar.enabled }}
       {{- range .Values.agent.extraSecretMounts }}
         - name: {{ .name }}

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -15,7 +15,7 @@ spec:
   - name: query
     port: {{ .Values.query.service.port }}
     protocol: TCP
-    targetPort: query
+    targetPort: {{ ternary "oauth-proxy" "query" .Values.query.oAuthSidecar.enabled }}
 {{- if and (eq .Values.query.service.type "NodePort") (.Values.query.service.nodePort) }}
     nodePort: {{ .Values.query.service.nodePort }}
 {{- end }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -367,6 +367,14 @@ collector:
 
 query:
   enabled: true
+  oAuthSidecar:
+    enabled: false
+    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
+    pullPolicy: IfNotPresent
+    containerPort: 4180
+    args: []
+    extraConfigmapMounts: []
+    extraSecretMounts: []
   podSecurityContext: {}
   securityContext: {}
   agentSidecar:


### PR DESCRIPTION
#### What this PR does
Adding a proxy sidecar (i.e. oauth2-proxy) to the query pod to enable TLS & authentication capabilities.

The idea originated by the following blogpost: https://medium.com/jaegertracing/protecting-jaeger-ui-with-an-oauth-sidecar-proxy-34205cca4bb1

It is up to the user to use any sidecar of their choice, with the necessary volumes mounting (configuration file/certs/key).

Example configuration when using the the [OAuth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/). 

#####  ConfigMap that contains the OAuth2-Porxy configuration
```yaml
apiVersion: v1
kind: ConfigMap
metadata:
  name: jaeger-oauth-proxy-config
data:
  oauth2-proxy.cfg: |
    provider = "oidc"
    https_address = ":4180"
    upstreams = ["http://localhost:16686"]
    redirect_url = "https://jaeger-svc-domain/oauth2/callback"
    client_id = "jaeger-query"
    client_secret = "xxxxxxxx"
    oidc_issuer_url = "https://keycloak-svc-domain/auth/realms/Default"
    cookie_secret = "RjdmcGVLMVNYaw=="
    cookie_secure = "true"
    provider_ca_files = ["/etc/tls/ca.crt"]
    tls_cert_file = "/etc/tls/tls.crt"
    tls_key_file = "/etc/tls/tls.key"
    email_domains = "*"
    oidc_groups_claim = "groups"
    user_id_claim = "preferred_username"
    skip_provider_button = "true"
```

#####  jaeger Helm chart values
```yaml
query:
  oAuthSidecar:
    enabled: true
    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
    args:
      - --config
      - /etc/oauth2-proxy/oauth2-proxy.cfg
    extraConfigmapMounts:
      - name: oauth2-proxy-config
        mountPath: /etc/oauth2-proxy
        configMap: jaeger-oauth-proxy-config
    extraSecretMounts:
      - name: oauth2-proxy-tls-secret
        secretName: oauth2-proxy-tls-secret
        mountPath: /etc/tls
    livenessProbe:
      httpGet:
        path: /ping
        port: oauth-proxy
        scheme: HTTPS
    readinessProbe:
      httpGet:
        path: /ping
        port: oauth-proxy
        scheme: HTTPS
```
Here assumes the `oauth2-proxy-tls-secret` is a valid `kubernetes.io/tls` type of secret contains the `tls.crt`, `tls.key`, and `ca.crt` certificate & keypair.

The jaeger-query service will point to the oauth2-proxy listener port, which has the capability to serve TLS and provide the authentication & authorization features.

#### Which issue this PR fixes
N/A

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
