### PR TITLE
[jaeger] Update Kafka helm chart version to use automountServiceAccountToken feature

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.44.1
+version: 0.45.0
 keywords:
   - jaeger
   - opentracing
@@ -34,6 +34,6 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^11.8.4
+    version: ^12.16.0
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka


### PR DESCRIPTION

Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does
It updates Kafka helm chart version from 11.x.x to 12.x.x. Its a major version upgrade but i looked at their changes, and most importantly they updated their charts api version to be v2 (compatible with helm3).

This is needed to we can use this change i made to the Kafka chart: https://github.com/bitnami/charts/pull/5988 and zookeeper chart:https://github.com/bitnami/charts/pull/5996

#### Which issue this PR fixes

N.A

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
