### PR TITLE
[Jaeger] Fix Indent in podAnnotations es-rollover-hook

### DIFF
--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -20,7 +20,7 @@ spec:
   template:
     metadata:
       {{- with .Values.esRollover.initHook.podAnnotations }}
-      annotations: {{- toYaml . | nindent 6 }}
+      annotations: {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}


### PR DESCRIPTION
#### What this PR does

Add 2 spaces in `podAnnotation`
