### PR TITLE
[jaeger-operator] update version of operator within the chart to v1.22.1

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.21.0
-appVersion: 1.22.0
+version: 2.21.1
+appVersion: 1.22.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -51,7 +51,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | Parameter               | Description                                                                                                 | Default                         |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.22.0`                        |
+| `image.tag`             | Controller container image tag                                                                              | `1.22.1`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.22.0
+  tag: 1.22.1
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
Signed-off-by: Chad Wilson <chadw@thoughtworks.com>

#### What this PR does

Bumps the default operator version in the chart to `1.22.1` to resolve https://github.com/jaegertracing/jaeger-operator/issues/1426 for those using the operator Helm chart (without having to override the image tag)

Bumped the Chart version to `2.22.0` since this will actually indirectly trigger upgrades to Jaeger `1.22.0` (from `1.21.0`).

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
