### PR TITLE
[jaeger]: Add option to use custom auth proxy with jaeger query 

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.45.3
+version: 0.46.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -202,6 +202,9 @@ spec:
             path: /
             port: admin
 {{- end }}
+      {{- if .Values.query.sidecars }}
+        {{- tpl (toYaml .Values.query.sidecars) . | nindent 8 }}
+      {{- end }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always
       volumes:
@@ -249,6 +252,9 @@ spec:
             name: {{ .configMap }}
       {{- end }}
 {{- end }}
+      {{- if .Values.query.extraVolumes }}
+        {{- tpl (toYaml .Values.query.extraVolumes) . | nindent 8 }}
+      {{- end }}
     {{- with .Values.query.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -15,7 +15,7 @@ spec:
   - name: query
     port: {{ .Values.query.service.port }}
     protocol: TCP
-    targetPort: {{ ternary "oauth-proxy" "query" .Values.query.oAuthSidecar.enabled }}
+    targetPort: {{ default (ternary "oauth-proxy" "query" .Values.query.oAuthSidecar.enabled) .Values.query.service.targetPort }}
 {{- if and (eq .Values.query.service.type "NodePort") (.Values.query.service.nodePort) }}
     nodePort: {{ .Values.query.service.nodePort }}
 {{- end }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -401,6 +401,8 @@ query:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     port: 80
+    # Specify a custom target port (e.g. port of auth proxy)
+    # targetPort: 8080
     # Specify a specific node port when type is NodePort
     # nodePort: 32500
   ingress:
@@ -445,6 +447,13 @@ query:
   #   subPath: ""
   #   configMap: jaeger-config
   #   readOnly: true
+  extraVolumes: []
+  sidecars: []
+  ##   - name: your-image-name
+  ##     image: your-image
+  ##     ports:
+  ##       - name: portname
+  ##         containerPort: 1234
   priorityClassName: ""
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
#### What this PR does

The PR adds the option to use a custom auth proxy with jaeger query by adding values to add additional `sidecars` to the jeager query pods and a value to customize the `targetPort` of the service. I also added another value to add `extraVolumes` which allows for more flexibility when configuring `sidecars`. Also even though the main use case for `sidecars` is probably to add a auth proxy it is not explicitly limited to that.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
