### PR TITLE
[jaeger-operator] Priority class name management

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.21.2
+version: 2.21.3
 appVersion: 1.22.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -67,6 +67,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `tolerations`           | Toleration labels for pod assignment                                                                        | `[]`                            |
 | `affinity`              | Affinity settings for pod assignment                                                                        | `{}`                            |
 | `securityContext`       | Security context for pod                                                                                    | `{}`                            |
+| `priorityClassName`     | Priority class name for the pod                                                                             | `None`                          |
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section.
 

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -23,6 +23,9 @@ spec:
       securityContext:
 {{ toYaml . | indent 8 }}
       {{- end }}
+      {{- if .Values.priorityClassName }}
+      priorityClassName: {{ .Values.priorityClassName | quote }}
+      {{- end }}
       {{- if and .Values.image.imagePullSecrets (not .Values.serviceAccount.create ) }}
       imagePullSecrets:
       {{- range .Values.image.imagePullSecrets }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -57,3 +57,5 @@ tolerations: []
 affinity: {}
 
 securityContext: {}
+
+priorityClassName:


### PR DESCRIPTION
Signed-off-by: Matteo Maponi <matteo.maponi@gmail.com>

#### What this PR does

Adds the ability to set a priority class name for the jaeger-operator chart. 

#### Which issue this PR fixes

- fixes https://github.com/jaegertracing/helm-charts/issues/255

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
