### PR TITLE
[jaeger] add environment variables to jaeger oauth sidecar

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.0
+version: 0.46.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -132,6 +132,10 @@ spec:
         {{- range .Values.query.oAuthSidecar.args }}
           - {{ . }}
         {{- end }}
+        {{- if .Values.query.oAuthSidecar.extraEnv }}
+        env:
+          {{- toYaml .Values.query.oAuthSidecar.extraEnv | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -381,6 +381,7 @@ query:
     pullPolicy: IfNotPresent
     containerPort: 4180
     args: []
+    extraEnv: []
     extraConfigmapMounts: []
     extraSecretMounts: []
   podSecurityContext: {}


### PR DESCRIPTION
#### What this PR does
This PR allows the passing of environment variables to the oauth2-proxy sidecar for Jaeger.

The environment variables are passed in values.yaml under the `extraEnv` key, and are then passed into the oauth2-sidecar container.

The reasoning for this is so that we can use kubernetes secrets as environment variables within the oauth proxy ConfigMap.

Example:
```
extraEnv:
  - name: test-env
    valueFrom:
      secretKeyRef:
        name: test-secret
        key: test-key
```
```
oAuthSidecar:
  enabled: true
  image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
  args:
    - --config
    - /etc/oauth2-proxy/oauth2-proxy.cfg
    - --client-secret
    - "$(test-env)"
```
#### Which issue this PR fixes

N/A

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
