### PR TITLE
[jaeger-operator] fix missing app.kubernetes.io/instance label

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.21.3
+version: 2.21.4
 appVersion: 1.22.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/_helpers.tpl
+++ b/charts/jaeger-operator/templates/_helpers.tpl
@@ -45,4 +45,5 @@ Create chart name and version as used by the chart label.
 {{/* Generate basic labels */}}
 {{- define "jaeger-operator.labels" }}
 app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}


### PR DESCRIPTION
#### What this PR does
This PR adds a missing label from the `_helpers.tpl` template file that causes the `jaeger-operator-metrics` `service` to not pickup the `jaeger-operator` `pod`.

#### Which issue this PR fixes
Fixes #247 
#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
