### PR TITLE
[jaeger] Reordering HPA metrics section

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.2
+version: 0.46.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-hpa.yaml
+++ b/charts/jaeger/templates/collector-hpa.yaml
@@ -14,14 +14,14 @@ spec:
   minReplicas: {{ .Values.collector.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.collector.autoscaling.maxReplicas }}
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.collector.autoscaling.targetCPUUtilizationPercentage | default 80 }}
   {{- if .Values.collector.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.collector.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.collector.autoscaling.targetCPUUtilizationPercentage | default 80 }}
 {{- end }}

--- a/charts/jaeger/templates/ingester-hpa.yaml
+++ b/charts/jaeger/templates/ingester-hpa.yaml
@@ -14,14 +14,14 @@ spec:
   minReplicas: {{ .Values.ingester.autoscaling.minReplicas }}
   maxReplicas: {{ .Values.ingester.autoscaling.maxReplicas }}
   metrics:
-    - type: Resource
-      resource:
-        name: cpu
-        targetAverageUtilization: {{ .Values.ingester.autoscaling.targetCPUUtilizationPercentage | default 80 }}
   {{- if .Values.ingester.autoscaling.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
         targetAverageUtilization: {{ .Values.ingester.autoscaling.targetMemoryUtilizationPercentage }}
   {{- end }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.ingester.autoscaling.targetCPUUtilizationPercentage | default 80 }}
 {{- end }}


### PR DESCRIPTION
Signed-off-by: sai kalyan <svytla@axon.com>

#### What this PR does
This PR fixes the HPA metrics list in a way that the order will be the same as how the HPA controller is saving it. There is a problem while using GitOps style of CD's like Argocd,harness...etc. The HPA controller is swaping the order of metrics section which is causing difference while using GitOps models CD's.
 Example of HPA for Argocd:
 HPA.yaml
```
spec:
  scaleTargetRef:
    apiVersion: apps/v1
    kind: Deployment
    name:  jaeger-collector
  minReplicas: 2
  maxReplicas: 10
  metrics:
    - type: Resource
      resource:
        name: cpu
        targetAverageUtilization: 90
    - type: Resource
      resource:
        name: memory
        targetAverageUtilization: 90

```
 Live Manifest that its applying:
```
  name: jaeger-collector
  namespace: jaeger-components
spec:
  maxReplicas: 10
  metrics:
    - resource:
        name: memory
        targetAverageUtilization: 90
      type: Resource
    - resource:
        name: cpu
        targetAverageUtilization: 90
      type: Resource
  minReplicas: 2
```
 Clearly, you see a difference in reordering of metrics section, which is causing outofsync kind of issues. So, if we can just reorder the memory & CPU resource it can solve it.

#### Which issue this PR fixes

https://github.com/argoproj/argo-cd/issues/1079

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
