### PR TITLE
[jaeger] Add a configmap for the jaeger oauth sidecar

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.1
+version: 0.46.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/oauth-sidecar-configmap.yaml
+++ b/charts/jaeger/templates/oauth-sidecar-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if and .Values.query.oAuthSidecar.enabled .Values.query.oAuthSidecar.config}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jaeger.fullname" . }}-oauth-configuration
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: query
+data:
+  oauth2-proxy.cfg: |-
+{{ tpl .Values.query.oAuthSidecar.config . | indent 4 }}
+{{- end }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -149,6 +149,10 @@ spec:
             subPath: {{ .subPath }}
             readOnly: {{ .readOnly }}
         {{- end }}
+        {{- if .Values.query.oAuthSidecar.config}}
+          - name: jaeger-oauth-configuration
+            mountPath: /etc/oauth2-proxy
+        {{- end }}
         ports:
           - containerPort: {{ .Values.query.oAuthSidecar.containerPort }}
             name: oauth-proxy
@@ -242,6 +246,11 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+      {{- end }}
+      {{- if .Values.query.oAuthSidecar.config }}
+        - name: jaeger-oauth-configuration
+          configMap:
+            name: {{ include "jaeger.fullname" . }}-oauth-configuration
       {{- end }}
 {{- end }}
 {{- if .Values.query.agentSidecar.enabled }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -384,6 +384,18 @@ query:
     extraEnv: []
     extraConfigmapMounts: []
     extraSecretMounts: []
+  # config: |-
+  #   provider = "oidc"
+  #   https_address = ":4180"
+  #   upstreams = ["http://localhost:16686"]
+  #   redirect_url = "https://jaeger-svc-domain/oauth2/callback"
+  #   client_id = "jaeger-query"
+  #   oidc_issuer_url = "https://keycloak-svc-domain/auth/realms/Default"
+  #   cookie_secure = "true"
+  #   email_domains = "*"
+  #   oidc_groups_claim = "groups"
+  #   user_id_claim = "preferred_username"
+  #   skip_provider_button = "true"
   podSecurityContext: {}
   securityContext: {}
   agentSidecar:


### PR DESCRIPTION
#### What this PR does

This PR adds an optional configmap to be deployed with the oauth2-proxy-sidecar. 

In values.yaml, if the `config` key in the `oAuthSidecar` yaml is added, then the `oauth-sidecar-configmap.yaml` is deployed with the specified data. If the `config` key is not passed, then the `oauth-sidecar-configmap` will not be deployed.

If the config is passed, it is then automatically added as a volume and mounted as `jaeger-oauth-configuration`under the path `/etc/oauth2-proxy`

example values.yaml:
```
oAuthSidecar:
  enabled: true
  image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
  pullPolicy: IfNotPresent
  containerPort: 4180
  args:
    - --config
    - /etc/oauth2-proxy/oauth2-proxy.cfg
  extraEnv: []
  extraConfigmapMounts: []
  extraSecretMounts: []
  config: |-
    provider = "oidc"
    https_address = ":4180"
    upstreams = ["http://localhost:16686"]
    redirect_url = "https://jaeger-svc-domain/oauth2/callback"
    client_id = "jaeger-query"
    oidc_issuer_url = "https://keycloak-svc-domain/auth/realms/Default"
    cookie_secure = "true"
    email_domains = "*"
    oidc_groups_claim = "groups"
    user_id_claim = "preferred_username"
    skip_provider_button = "true"
```

#### Which issue this PR fixes

Per initial PR https://github.com/jaegertracing/helm-charts/pull/231 for the oauth sidecar, the configmap had to be deployed manually outside of the jaeger helm chart.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
