### PR TITLE
[jaeger-operator]: fix the problem with upgrade chart

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.21.4
+version: 2.21.5
 appVersion: 1.22.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -9,7 +9,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-{{ include "jaeger-operator.labels" . | indent 6 }}
+    {{- if .Release.IsUpgrade }}
+      app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
+    {{- else }}
+      {{ include "jaeger-operator.labels" . | nindent 8 }}
+    {{- end }}
   template:
     metadata:
       name: {{ include "jaeger-operator.fullname" . }}


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

Resolves the conflict of immutable labels when upgrading from an older version

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
