### PR TITLE
[jaeger]: Add activeDeadlineSeconds value to all jobs

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.3
+version: 0.46.4
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -18,6 +18,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      {{- if .Values.esIndexCleaner.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.esIndexCleaner.activeDeadlineSeconds }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esIndexCleaner.podAnnotations }}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -18,6 +18,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      {{- if .Values.esLookback.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.esLookback.activeDeadlineSeconds }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esLookback.podAnnotations }}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -18,6 +18,9 @@ spec:
   suspend: false
   jobTemplate:
     spec:
+      {{- if .Values.esRollover.activeDeadlineSeconds }}
+      activeDeadlineSeconds: {{ .Values.esRollover.activeDeadlineSeconds }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esRollover.podAnnotations }}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -13,6 +13,9 @@ metadata:
       {{- toYaml .Values.esRollover.initHook.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if .Values.esRollover.initHook.activeDeadlineSeconds }}
+  activeDeadlineSeconds: {{ .Values.esRollover.initHook.activeDeadlineSeconds }}
+  {{- end }}
   {{- with .Values.esRollover.initHook.ttlSecondsAfterFinished }}
   ttlSecondsAfterFinished: {{ . }}
   {{- end }}


### PR DESCRIPTION
#### What this PR does

Adds `activeDeadlineSeconds` value to all jobs to allow chart users to set a job deadlines which is currently required to terminate a job if sidecars are used.  This issue is also described [here](https://github.com/kubernetes/kubernetes/issues/25908) and there is not yet a proper solution for this.

An example use case would be if you are running elasticsearch in a service mesh which means in order for the job containers to send requests to elasticsearch it is required to also add them to the mesh hence injecting additional sidecars. The jobs will not finish by themselves since the sidecars are not shutting down which is a big issue for the hook/init job but also for all cronjobs because the pods are not cleaned up after the jobs finishes.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
