### PR TITLE
[jaeger]: Only add ServiceMonitor resources if crd exists

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.4
+version: 0.46.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-servicemonitor.yaml
+++ b/charts/jaeger/templates/agent-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.agent.enabled) (.Values.agent.serviceMonitor.enabled)}}
+{{- if and (.Values.agent.enabled) (.Values.agent.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/jaeger/templates/collector-servicemonitor.yaml
+++ b/charts/jaeger/templates/collector-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.collector.enabled) (.Values.collector.serviceMonitor.enabled)}}
+{{- if and (.Values.collector.enabled) (.Values.collector.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/jaeger/templates/ingester-servicemonitor.yaml
+++ b/charts/jaeger/templates/ingester-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.ingester.enabled) (.Values.ingester.serviceMonitor.enabled)}}
+{{- if and (.Values.ingester.enabled) (.Values.ingester.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:

--- a/charts/jaeger/templates/query-servicemonitor.yaml
+++ b/charts/jaeger/templates/query-servicemonitor.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.query.enabled) (.Values.query.serviceMonitor.enabled)}}
+{{- if and (.Values.query.enabled) (.Values.query.serviceMonitor.enabled) (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1")}}
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:


### PR DESCRIPTION
#### What this PR does

The PR adds a check to all `ServiceMonitor` to only add them if the crd (`monitoring.coreos.com/v1` api) exists. This allows to set `<component>.serviceMonitor.enabled` to `true` while ensuring that the installation of the whole chart does not fail just because the `ServiceMonitor` resource can not be created.

Potential consideration is that now if `<component>.serviceMonitor.enabled`  is set to `true` but the `monitoring.coreos.com/v1` does not exist it will silently not create the resources instead of throwing an error when installing the chart. Not sure if this should be considered a disadvantage.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
