### PR TITLE
[jaeger] use networking.k8s.io/v1 for ingreses if available

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.4
+version: 0.46.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,7 +1,12 @@
+{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.collector.ingress.enabled -}}
 {{- $servicePort := .Values.collector.service.http.port -}}
 {{- $basePath := .Values.collector.basePath -}}
+{{- if $useNetworkingV1 }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "jaeger.collector.name" . }}
@@ -19,9 +24,18 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
+            {{- if $useNetworkingV1 }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+               name: {{ template "jaeger.collector.name" $ }}
+               port:
+                 number: {{ $servicePort }}
+            {{- else }}
             backend:
               serviceName: {{ template "jaeger.collector.name" $ }}
               servicePort: {{ $servicePort }}
+            {{- end }}
     {{- end -}}
   {{- if .Values.collector.ingress.tls }}
   tls:

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -1,8 +1,13 @@
+{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.hotrod.enabled -}}
 {{- if .Values.hotrod.ingress.enabled -}}
 {{- $serviceName := include "jaeger.fullname" . -}}
 {{- $servicePort := .Values.hotrod.service.port -}}
+{{- if $useNetworkingV1 }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ include "jaeger.fullname" . }}-hotrod
@@ -20,9 +25,18 @@ spec:
       http:
         paths:
           - path: /
+            {{- if $useNetworkingV1 }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+               name: {{ $serviceName }}-hotrod
+               port:
+                 number: {{ $servicePort }}
+            {{- else }}
             backend:
               serviceName: {{ $serviceName }}-hotrod
               servicePort: {{ $servicePort }}
+            {{- end }}
     {{- end -}}
   {{- if .Values.hotrod.ingress.tls }}
   tls:

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -1,7 +1,12 @@
+{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.query.ingress.enabled -}}
 {{- $servicePort := .Values.query.service.port -}}
 {{- $basePath := .Values.query.basePath -}}
+{{- if $useNetworkingV1 }}
+apiVersion: networking.k8s.io/v1
+{{- else }}
 apiVersion: networking.k8s.io/v1beta1
+{{- end }}
 kind: Ingress
 metadata:
   name: {{ template "jaeger.query.name" . }}
@@ -19,15 +24,33 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
+            {{- if $useNetworkingV1 }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+               name: {{ template "jaeger.query.name" $ }}
+               port:
+                 number: {{ $servicePort }}
+            {{- else }}
             backend:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: {{ $servicePort }}
+            {{- end }}
     {{- end -}}
     {{- if .Values.query.ingress.health.exposed }}
           - path: /health
+            {{- if $useNetworkingV1 }}
+            pathType: ImplementationSpecific
+            backend:
+              service:
+               name: {{ template "jaeger.query.name" $ }}
+               port:
+                 number: 16687
+            {{- else }}
             backend:
               serviceName: {{ template "jaeger.query.name" $ }}
               servicePort: 16687
+            {{- end }}
     {{- end -}}
   {{- if .Values.query.ingress.tls }}
   tls:


### PR DESCRIPTION
Signed-off-by: bender316 <bender316@gmail.com>

#### What this PR does

Starting with kubernetes v1.22 the old api version "networking.k8s.io/v1beta1" for ingresses is no longer supported. This PR supports now both flavors.

#### Which issue this PR fixes

- fixes #273 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
