### PR TITLE
[jaeger] Include bitnami's common chart to fix Ingress v1/v1beta1 distinction

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.46.5
+version: 0.46.6
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -37,3 +37,6 @@ dependencies:
     version: ^12.16.0
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
+  - name: common
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.8.0

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,12 +1,7 @@
-{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.collector.ingress.enabled -}}
-{{- $servicePort := .Values.collector.service.http.port -}}
-{{- $basePath := .Values.collector.basePath -}}
-{{- if $useNetworkingV1 }}
-apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+  {{- $servicePort := .Values.collector.service.http.port -}}
+  {{- $basePath := .Values.collector.basePath -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ template "jaeger.collector.name" . }}
@@ -15,7 +10,7 @@ metadata:
     app.kubernetes.io/component: collector
   {{- if .Values.collector.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
+  {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
   {{- end }}
 spec:
   rules:
@@ -24,21 +19,13 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if $useNetworkingV1 }}
+            {{- if (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
-            backend:
-              service:
-               name: {{ template "jaeger.collector.name" $ }}
-               port:
-                 number: {{ $servicePort }}
-            {{- else }}
-            backend:
-              serviceName: {{ template "jaeger.collector.name" $ }}
-              servicePort: {{ $servicePort }}
             {{- end }}
-    {{- end -}}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.collector.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
+  {{- end -}}
   {{- if .Values.collector.ingress.tls }}
   tls:
-    {{- toYaml .Values.collector.ingress.tls | nindent 4 }}
+  {{- toYaml .Values.collector.ingress.tls | nindent 4 }}
   {{- end -}}
-{{- end -}}
+  {{- end -}}

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/component: collector
   {{- if .Values.collector.ingress.annotations }}
   annotations:
-  {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
-  {{- end }}
+    {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
+    {{- end }}
 spec:
   rules:
     {{- range $host := .Values.collector.ingress.hosts }}

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.collector.ingress.enabled -}}
-  {{- $servicePort := .Values.collector.service.http.port -}}
-  {{- $basePath := .Values.collector.basePath -}}
+{{- $servicePort := .Values.collector.service.http.port -}}
+{{- $basePath := .Values.collector.basePath -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -11,8 +11,8 @@ metadata:
     app.kubernetes.io/component: hotrod
   {{- if .Values.hotrod.ingress.annotations }}
   annotations:
-  {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
-  {{- end }}
+    {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
+    {{- end }}
 spec:
   rules:
     {{- range $host := .Values.hotrod.ingress.hosts }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -1,23 +1,18 @@
-{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.hotrod.enabled -}}
-{{- if .Values.hotrod.ingress.enabled -}}
-{{- $serviceName := include "jaeger.fullname" . -}}
-{{- $servicePort := .Values.hotrod.service.port -}}
-{{- if $useNetworkingV1 }}
-apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+  {{- if .Values.hotrod.ingress.enabled -}}
+  {{- $serviceName := include "jaeger.fullname" . -}}
+  {{- $servicePort := .Values.hotrod.service.port -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ include "jaeger.fullname" . }}-hotrod
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: hotrod
-{{- if .Values.hotrod.ingress.annotations }}
+  {{- if .Values.hotrod.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
-{{- end }}
+  {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
   rules:
     {{- range $host := .Values.hotrod.ingress.hosts }}
@@ -25,22 +20,14 @@ spec:
       http:
         paths:
           - path: /
-            {{- if $useNetworkingV1 }}
+            {{- if (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
-            backend:
-              service:
-               name: {{ $serviceName }}-hotrod
-               port:
-                 number: {{ $servicePort }}
-            {{- else }}
-            backend:
-              serviceName: {{ $serviceName }}-hotrod
-              servicePort: {{ $servicePort }}
             {{- end }}
-    {{- end -}}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-hotrod" $serviceName) "servicePort" $servicePort "context" $) | nindent 14 }}
+  {{- end -}}
   {{- if .Values.hotrod.ingress.tls }}
   tls:
-    {{- toYaml .Values.hotrod.ingress.tls | nindent 4 }}
+  {{- toYaml .Values.hotrod.ingress.tls | nindent 4 }}
   {{- end -}}
-{{- end -}}
-{{- end -}}
+  {{- end -}}
+  {{- end -}}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -1,12 +1,7 @@
-{{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
 {{- if .Values.query.ingress.enabled -}}
-{{- $servicePort := .Values.query.service.port -}}
-{{- $basePath := .Values.query.basePath -}}
-{{- if $useNetworkingV1 }}
-apiVersion: networking.k8s.io/v1
-{{- else }}
-apiVersion: networking.k8s.io/v1beta1
-{{- end }}
+  {{- $servicePort := .Values.query.service.port -}}
+  {{- $basePath := .Values.query.basePath -}}
+apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
 metadata:
   name: {{ template "jaeger.query.name" . }}
@@ -15,7 +10,7 @@ metadata:
     app.kubernetes.io/component: query
   {{- if .Values.query.ingress.annotations }}
   annotations:
-    {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
+  {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
   {{- end }}
 spec:
   rules:
@@ -24,36 +19,20 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if $useNetworkingV1 }}
+            {{- if (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
-            backend:
-              service:
-               name: {{ template "jaeger.query.name" $ }}
-               port:
-                 number: {{ $servicePort }}
-            {{- else }}
-            backend:
-              serviceName: {{ template "jaeger.query.name" $ }}
-              servicePort: {{ $servicePort }}
             {{- end }}
-    {{- end -}}
-    {{- if .Values.query.ingress.health.exposed }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
+          {{- end -}}
+          {{- if .Values.query.ingress.health.exposed }}
           - path: /health
-            {{- if $useNetworkingV1 }}
+            {{- if (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
-            backend:
-              service:
-               name: {{ template "jaeger.query.name" $ }}
-               port:
-                 number: 16687
-            {{- else }}
-            backend:
-              serviceName: {{ template "jaeger.query.name" $ }}
-              servicePort: 16687
             {{- end }}
-    {{- end -}}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16687 "context" $) | nindent 14 }}
+  {{- end -}}
   {{- if .Values.query.ingress.tls }}
   tls:
-    {{- toYaml .Values.query.ingress.tls | nindent 4 }}
+  {{- toYaml .Values.query.ingress.tls | nindent 4 }}
   {{- end -}}
-{{- end -}}
+  {{- end -}}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -10,8 +10,8 @@ metadata:
     app.kubernetes.io/component: query
   {{- if .Values.query.ingress.annotations }}
   annotations:
-  {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
-  {{- end }}
+    {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
+    {{- end }}
 spec:
   rules:
     {{- range $host := .Values.query.ingress.hosts }}


### PR DESCRIPTION
Replace Ingress `v1`/`v1beta1` logic

Signed-off-by: Chris Werner Rau <cwrau@cwrcoding.com>

#### What this PR does

Uses bitnami's `common` chart to replace the Ingress `v1`/`v1beta1` logic, as that had a flaw

#### Which issue this PR fixes

- fixes #277

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
