### PR TITLE
[jaeger] Check for using "networking.k8s.io/v1" is incorrect

### DIFF
--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -2,7 +2,7 @@
 {{- if .Values.query.ingress.enabled -}}
 {{- $servicePort := .Values.query.service.port -}}
 {{- $basePath := .Values.query.basePath -}}
-{{- if $useNetworkingV1 }}
+{{- if semverCompare ">=1.19" .Capabilities.KubeVersion.Version -}}
 apiVersion: networking.k8s.io/v1
 {{- else }}
 apiVersion: networking.k8s.io/v1beta1


### PR DESCRIPTION
the check for 
you have applied:  {{- $useNetworkingV1 := .Capabilities.APIVersions.Has "networking.k8s.io/v1" -}}
this is true for older versions of k8s as well but in older version, "networking.k8s.io/v1" does not have Ingress.
please apply the version check:

kubernetes version 1.19+ has ingress in "networking.k8s.io/v1"

#### What this PR does

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
