### PR TITLE
[jaeger-operator] Enable extraLabels to deployment

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.23.0
+version: 2.24.0
 appVersion: 1.24.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -50,6 +50,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 
 | Parameter               | Description                                                                                                 | Default                         |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
+| `extraLabels`           | Additional labels to jaeger-operator deployment  | `{}`
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
 | `image.tag`             | Controller container image tag                                                                              | `1.24.0`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
+{{- with .Values.extraLabels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
 spec:
   replicas: 1
   selector:
@@ -15,6 +18,9 @@ spec:
       name: {{ include "jaeger-operator.fullname" . }}
       labels:
 {{ include "jaeger-operator.labels" . | indent 8 }}
+{{- with .Values.extraLabels }}
+{{ . | toYaml | indent 8 }}
+{{- end }}
     spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "jaeger-operator.serviceAccountName" . }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -42,6 +42,10 @@ extraEnv: []
   # - name: LOG-LEVEL
   #   value: debug
 
+extraLabels: {}
+  # Specifies extra labels for the operator deployment:
+  # foo: bar
+
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
#### What this PR does
Title explains itself but...
It enables custom labels for jaeger-operator deployment; We might need it for several reasons but in my case: to add a `cost-center` label in its pods.

#### Which issue this PR fixes
n/a

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
