### PR TITLE
[jaeger-operator] fix(#272): update crd to closer match the jaeger-operator original

### DIFF
--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -32,3 +32,16 @@ spec:
           description: Jaeger Version
           name: Version
           type: string
+        - description: Jaeger deployment strategy
+          jsonPath: .spec.strategy
+          name: Strategy
+          type: string
+        - description: Jaeger storage type
+          jsonPath: .spec.storage.type
+          name: Storage
+          type: string
+        - jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      subresources:
+        status: {}


### PR DESCRIPTION
#### What this PR does

Update the CRD definition to match the released version 'v1.25.0' of the jaeger-perator

#### Which issue this PR fixes

- fixes #272 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
