### PR TITLE
[jaeger] Make service port and host of collector ingress configurable

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.49.0
+version: 0.50.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -158,6 +158,28 @@ Create the name of the collector service account to use
 {{- end -}}
 
 {{/*
+Create the collector ingress host
+*/}}
+{{- define "jaeger.collector.ingressHost" -}}
+{{- if (kindIs "string" .) }}
+  {{- . }}
+{{- else }}
+  {{- .host }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Create the collector ingress servicePort
+*/}}
+{{- define "jaeger.collector.ingressServicePort" -}}
+{{- if (kindIs "string" .context) }}
+  {{- .defaultServicePort }}
+{{- else }}
+  {{- .context.servicePort }}
+{{- end }}
+{{- end -}}
+
+{{/*
 Create the name of the ingester service account to use
 */}}
 {{- define "jaeger.ingester.serviceAccountName" -}}

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,5 +1,5 @@
 {{- if .Values.collector.ingress.enabled -}}
-{{- $servicePort := .Values.collector.service.http.port -}}
+{{- $defaultServicePort := .Values.collector.service.http.port -}}
 {{- $basePath := .Values.collector.basePath -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
 kind: Ingress
@@ -14,14 +14,16 @@ metadata:
     {{- end }}
 spec:
   rules:
-    {{- range $host := .Values.collector.ingress.hosts }}
-    - host: {{ $host }}
+    {{- range .Values.collector.ingress.hosts }}
+    - host: {{ include "jaeger.collector.ingressHost" . }}
       http:
         paths:
           - path: {{ $basePath }}
             {{- if (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
             {{- end }}
+            {{- $servicePortString := (include "jaeger.collector.ingressServicePort" (dict "defaultServicePort" $defaultServicePort "context" .)) }}
+            {{- $servicePort := default $servicePortString ($servicePortString | float64) }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.collector.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.collector.ingress.tls }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -300,8 +300,13 @@ collector:
     enabled: false
     annotations: {}
     # Used to create an Ingress record.
+    # The 'hosts' variable accepts two formats:
     # hosts:
     #   - chart-example.local
+    # or:
+    # hosts:
+    #   - host: chart-example.local
+    #     servicePort: grpc
     # annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
Signed-off-by: Jonas Höpfner <jonashoepfner@gmx.de>

#### What this PR does

This PR changes the collector ingress and makes the bound service port configurable. The new configuration of `collector.ingress.hosts` is backwards compatible and accepts the previous, as well as the new format.

#### Which issue this PR fixes

- fixes #264

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
