### PR TITLE
[jaeger] chore: adding collector supports install in new namespace

### DIFF
--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -230,6 +230,14 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- end -}}
 
 {{/*
+Create a fully qualified collector host.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "jaeger.collector.host" -}}
+{{- printf "%s.%s" (include "jaeger.fullname" .) .Release.Namespace  | trunc 63 -}}
+{{- end -}}
+
+{{/*
 Create a fully qualified ingester name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -70,7 +70,7 @@ spec:
         {{- end }}
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
           - name: REPORTER_GRPC_HOST_PORT
-            value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
+            value: {{ include "jaeger.collector.host" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
         ports:
         - name: zipkin-compact

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -182,7 +182,7 @@ spec:
         env:
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
         - name: REPORTER_GRPC_HOST_PORT
-          value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
+          value: {{ include "jaeger.collector.host" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
         ports:
         - name: admin


### PR DESCRIPTION
Signed-off-by: Marco Dalalba <vinisdl@hotmail.com>
#### What this PR does
Allows you to install jaeger in a namespace other than the default.


#### Checklist

- [x]  [DCO] (https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed

- [ ] Commitments are [signed by GPG] (https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] The graphic version has collapsed
- [x] The PR title starts with the chart name (`[jaeger]` or `[jaeger-operator]`)