### PR TITLE
[jaeger] add ingressClassName support

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.51.0
+version: 0.51.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.collector.ingress.enabled -}}
+{{- $ingressSupportsIngressClassName := eq (include "common.ingress.supportsIngressClassname" .) "true" }}
 {{- $defaultServicePort := .Values.collector.service.http.port -}}
 {{- $basePath := .Values.collector.basePath -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
@@ -13,6 +14,9 @@ metadata:
     {{- toYaml .Values.collector.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and $ingressSupportsIngressClassName .Values.collector.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.collector.ingress.ingressClassName }}
+  {{- end -}}
   rules:
     {{- range .Values.collector.ingress.hosts }}
     - host: {{ include "jaeger.collector.ingressHost" . }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.hotrod.enabled -}}
   {{- if .Values.hotrod.ingress.enabled -}}
+  {{- $ingressSupportsIngressClassName := eq (include "common.ingress.supportsIngressClassname" .) "true" }}
   {{- $serviceName := include "jaeger.fullname" . -}}
   {{- $servicePort := .Values.hotrod.service.port -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
@@ -14,6 +15,9 @@ metadata:
     {{- toYaml .Values.hotrod.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and $ingressSupportsIngressClassName .Values.hotrod.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.hotrod.ingress.ingressClassName }}
+  {{- end -}}
   rules:
     {{- range $host := .Values.hotrod.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.query.ingress.enabled -}}
+{{- $ingressSupportsIngressClassName := eq (include "common.ingress.supportsIngressClassname" .) "true" }}
   {{- $servicePort := .Values.query.service.port -}}
   {{- $basePath := .Values.query.basePath -}}
 apiVersion: {{ include "common.capabilities.ingress.apiVersion" $ }}
@@ -13,6 +14,9 @@ metadata:
     {{- toYaml .Values.query.ingress.annotations | nindent 4 }}
     {{- end }}
 spec:
+  {{- if and $ingressSupportsIngressClassName .Values.query.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.query.ingress.ingressClassName }}
+  {{- end -}}
   rules:
     {{- range $host := .Values.query.ingress.hosts }}
     - host: {{ $host }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -298,6 +298,9 @@ collector:
       # nodePort:
   ingress:
     enabled: false
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
     annotations: {}
     # Used to create an Ingress record.
     # The 'hosts' variable accepts two formats:
@@ -438,6 +441,9 @@ query:
     # nodePort: 32500
   ingress:
     enabled: false
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
     annotations: {}
     # Used to create an Ingress record.
     # hosts:
@@ -689,6 +695,9 @@ hotrod:
     port: 80
   ingress:
     enabled: false
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
     # Used to create Ingress record (should be used with service.type: ClusterIP).
     hosts:
       - chart-example.local


### PR DESCRIPTION
#### What this PR does
Adds support for ingressClassName with keeping the old annotation option
#### Which issue this PR fixes

- fixes #236 

#### Checklist

- [V] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [V] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [V] Chart Version bumped
- [V] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
