### PR TITLE
[jaeger] fixed common.ingress.supportsPathType condition

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.22.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.50.0
+version: 0.50.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -19,7 +19,7 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if (include "common.ingress.supportsPathType" $) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
             {{- end }}
             {{- $servicePortString := (include "jaeger.collector.ingressServicePort" (dict "defaultServicePort" $defaultServicePort "context" .)) }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -20,7 +20,7 @@ spec:
       http:
         paths:
           - path: /
-            {{- if (include "common.ingress.supportsPathType" $) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-hotrod" $serviceName) "servicePort" $servicePort "context" $) | nindent 14 }}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -19,14 +19,14 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if (include "common.ingress.supportsPathType" $) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
           {{- end -}}
           {{- if .Values.query.ingress.health.exposed }}
           - path: /health
-            {{- if (include "common.ingress.supportsPathType" $) }}
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
             pathType: ImplementationSpecific
             {{- end }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16687 "context" $) | nindent 14 }}


### PR DESCRIPTION
Signed-off-by: Scharly Ochoa <sochoa@outlook.com.pe>

#### What this PR does

Currently pathType is added even when common.ingress.supportsPathType returns "false", this PR fixes the common.ingress.supportsPathType condition in all the ingress templates.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
