### PR TITLE
[jaeger] Fix no newline before rules in query-ing.yaml

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.51.1
+version: 0.51.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.query.ingress.ingressClassName }}
   ingressClassName: {{ .Values.query.ingress.ingressClassName }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range $host := .Values.query.ingress.hosts }}
     - host: {{ $host }}


### PR DESCRIPTION
Fix an issue introduced in v0.50.0 which causes no newline before the `rules` in `query-ing.yaml` when `query.ingress=true`.

![Screenshot-20211117002501-296x46](https://user-images.githubusercontent.com/3839678/142026157-190459dd-d51b-408b-9c49-acc14201e9e4.png)

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
