### PR TITLE
[jaeger] Fix no newline before rules in collector-ing.yaml & hotrod-ing.yaml

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.51.2
+version: 0.51.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -16,7 +16,7 @@ metadata:
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.collector.ingress.ingressClassName }}
   ingressClassName: {{ .Values.collector.ingress.ingressClassName }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range .Values.collector.ingress.hosts }}
     - host: {{ include "jaeger.collector.ingressHost" . }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -17,7 +17,7 @@ metadata:
 spec:
   {{- if and $ingressSupportsIngressClassName .Values.hotrod.ingress.ingressClassName }}
   ingressClassName: {{ .Values.hotrod.ingress.ingressClassName }}
-  {{- end -}}
+  {{- end }}
   rules:
     {{- range $host := .Values.hotrod.ingress.hosts }}
     - host: {{ $host }}


### PR DESCRIPTION
Fix an issue introduced in v0.50.0 which causes no newline before the `rules` in `collector-ing.yaml` & `hotrod-ing.yaml` when `query.ingress=true`.

![image](https://user-images.githubusercontent.com/3839678/142047395-c225cd6e-b10a-4bb2-84b5-28602522487f.png)
![image](https://user-images.githubusercontent.com/3839678/142047416-9615e1e6-2a15-48b1-bb74-73571eed633e.png)

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
