### PR TITLE
[jaeger] use jaeger.image.tag for es-index-cleaner tag

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.51.4
+version: 0.51.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -551,9 +551,7 @@ esIndexCleaner:
     runAsUser: 1000
   annotations: {}
   image: jaegertracing/jaeger-es-index-cleaner
-  # tag: 1.22
   imagePullSecrets: []
-  tag: latest
   pullPolicy: Always
   cmdlineParams: {}
   extraEnv: []


### PR DESCRIPTION
Signed-off-by: Manuel Bonk <gh@mbonk.de>

#### What this PR does

This PR sets the default image tag for `jaeger-es-index-cleaner` cronjob  from `latest` to  `jaeger.image.tag` (see https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/templates/es-index-cleaner-cronjob.yaml#L48) In case you want to override the tag you can still do so manually, but I think it shouldn't be set by default to `latest`.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
