### PR TITLE
[jaeger] Add support for all-in-one deployment with in-memory storage

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.51.5
+version: 0.52.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -70,6 +70,9 @@ team [recommends Elasticsearch backend over Cassandra](https://www.jaegertracing
 as such the default backend may change in the future and **it is highly
 recommended to explicitly configure storage**.
 
+If you are just starting out with a testing/demo setup, you can also use in-memory storage for a
+fast and easy setup experience using the [Jaeger All in One executable](https://www.jaegertracing.io/docs/1.29/getting-started/#all-in-one).
+
 ### Elasticsearch configuration
 
 #### Elasticsearch Rollover
@@ -262,6 +265,34 @@ helm install jaeger jaegertracing/jaeger \
   --set ingester.enabled=true \
   --set storage.kafka.brokers={<BROKER1:PORT>,<BROKER2:PORT>} \
   --set storage.kafka.topic=<TOPIC>
+```
+
+### All in One In-Memory Configuration
+
+#### Installing the Chart using the All in One executable and in-memory storage
+
+To install the chart with the release name `jaeger` using in-memory storage and the All in One
+executable, configure the chart as follows:
+
+Content of the `values.yaml` file:
+
+```yaml
+provisionDataStore:
+  cassandra: false
+allInOne:
+  enabled: true
+storage:
+  type: none
+agent:
+  enabled: false
+collector:
+  enabled: false
+query:
+  enabled: false
+```
+
+```bash
+helm install jaeger jaegertracing/jaeger --values values.yaml
 ```
 
 ## oAuth2 Sidecar

--- a/charts/jaeger/templates/allinone-agent-svc.yaml
+++ b/charts/jaeger/templates/allinone-agent-svc.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.agent.name" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: service-agent
+spec:
+  clusterIP: None
+  ports:
+    - name: zk-compact-trft
+      port: 5775
+      protocol: UDP
+      targetPort: 0
+    - name: config-rest
+      port: 5778
+      targetPort: 0
+    - name: jg-compact-trft
+      port: 6831
+      protocol: UDP
+      targetPort: 0
+    - name: jg-binary-trft
+      port: 6832
+      protocol: UDP
+      targetPort: 0
+  selector:
+    {{- include "jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+{{- end -}}

--- a/charts/jaeger/templates/allinone-collector-svc.yaml
+++ b/charts/jaeger/templates/allinone-collector-svc.yaml
@@ -1,0 +1,27 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.collector.name" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: service-collector
+spec:
+  clusterIP: None
+  ports:
+    - name: http-zipkin
+      port: 9411
+      targetPort: 0
+    - name: grpc-http
+      port: 14250
+      targetPort: 0
+    - name: c-tchan-trft
+      port: 14267
+      targetPort: 0
+    - name: http-c-binary-trft
+      port: 14268
+      targetPort: 0
+  selector:
+    {{- include "jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+{{- end -}}

--- a/charts/jaeger/templates/allinone-configmap.yaml
+++ b/charts/jaeger/templates/allinone-configmap.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.allInOne.samplingConfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "jaeger.fullname" . }}-sampling-strategies
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+data:
+  strategies.json: |-
+{{ tpl .Values.allInOne.samplingConfig . | indent 4 }}
+{{- end }}

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -1,0 +1,88 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ template "jaeger.fullname" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+    prometheus.io/port: "14269"
+    prometheus.io/scrape: "true"
+spec:
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "jaeger.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/component: all-in-one
+  template:
+    metadata:
+      labels:
+        {{- include "jaeger.selectorLabels" . | nindent 8 }}
+        app.kubernetes.io/component: all-in-one
+      annotations:
+        prometheus.io/port: "14269"
+        prometheus.io/scrape: "true"
+    spec:
+      containers:
+        - env:
+            - name: SPAN_STORAGE_TYPE
+              value: memory
+            - name: COLLECTOR_ZIPKIN_HOST_PORT
+              value: :9411
+            - name: JAEGER_DISABLED
+              value: "false"
+            {{- if .Values.allInOne.samplingConfig }}
+            - name: SAMPLING_STRATEGIES_FILE
+              value: /etc/conf/strategies.json
+            {{- end }}
+          image: {{ .Values.allInOne.image }}:{{- .Values.allInOne.tag | default (include "jaeger.image.tag" .) }}
+          imagePullPolicy: {{ .Values.allInOne.pullPolicy }}
+          name: jaeger
+          ports:
+            - containerPort: 5775
+              protocol: UDP
+            - containerPort: 6831
+              protocol: UDP
+            - containerPort: 6832
+              protocol: UDP
+            - containerPort: 5778
+              protocol: TCP
+            - containerPort: 16686
+              protocol: TCP
+            - containerPort: 9411
+              protocol: TCP
+          livenessProbe:
+            failureThreshold: 5
+            httpGet:
+              path: /
+              port: 14269
+              scheme: HTTP
+            initialDelaySeconds: 5
+            periodSeconds: 15
+            successThreshold: 1
+            timeoutSeconds: 1
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 14269
+              scheme: HTTP
+            initialDelaySeconds: 1
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 1
+        {{- if .Values.allInOne.samplingConfig}}
+          volumeMounts:
+            - name: strategies
+              mountPath: /etc/conf/
+        {{- end }}
+      serviceAccountName: {{ template "jaeger.fullname" . }}
+    {{- if .Values.allInOne.samplingConfig}}
+      volumes:
+        - name: strategies
+          configMap:
+            name: {{ include "jaeger.fullname" . }}-sampling-strategies
+    {{- end }}
+{{- end -}}

--- a/charts/jaeger/templates/allinone-ing.yaml
+++ b/charts/jaeger/templates/allinone-ing.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ template "jaeger.query.name" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+spec:
+  defaultBackend:
+    service:
+      name: {{ template "jaeger.query.name" . }}
+      port:
+        number: 16686
+{{- end -}}

--- a/charts/jaeger/templates/allinone-query-svc.yaml
+++ b/charts/jaeger/templates/allinone-query-svc.yaml
@@ -1,0 +1,21 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "jaeger.query.name" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: service-query
+spec:
+  clusterIP: None
+  ports:
+    - name: http-query
+      port: 16686
+      targetPort: 16686
+    - name: grpc-query
+      port: 16685
+      targetPort: 16685
+  selector:
+    {{- include "jaeger.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+{{- end -}}

--- a/charts/jaeger/templates/allinone-sa.yaml
+++ b/charts/jaeger/templates/allinone-sa.yaml
@@ -1,0 +1,9 @@
+{{- if .Values.allInOne.enabled -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "jaeger.fullname" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+{{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -13,6 +13,20 @@ tag: ""
 nameOverride: ""
 fullnameOverride: ""
 
+allInOne:
+  enabled: false
+  image: jaegertracing/all-in-one
+  tag: 1.29.0
+  pullPolicy: IfNotPresent
+  # samplingConfig: |-
+  #   {
+  #     "default_strategy": {
+  #       "type": "probabilistic",
+  #       "param": 1
+  #     }
+  #   }
+
+
 storage:
   # allowed values (cassandra, elasticsearch)
   type: cassandra


### PR DESCRIPTION
#### What this PR does
This PR adds support for deploying the all-in-one container using the jaeger Helm chart. The all-in-one deployment deploys the following resources:

- Deployment for all-in-one container
- ServiceAccount for all-in-one container deployment
- ConfigMap for sampling config analogous to the sampling config ConfigMap used for jaeger-collector deployment
- Service for jaeger-agent
- Service for jaeger-collector
- Service for jaeger-query
- Ingress with jaeger-query as backend

#### Which issue this PR fixes

- fixes #192 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
