### PR TITLE
[jaeger] Upgrade Kafka chart dependency from 12.x to 14.x

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.28.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.52.0
+version: 0.53.0
 keywords:
   - jaeger
   - opentracing
@@ -34,7 +34,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^12.16.0
+    version: ^14.9.1
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common


### PR DESCRIPTION
Signed-off-by: Greg Burton <9094087+gburton1@users.noreply.github.com>

#### What this PR does
Upgrades Kafka dependency to more recent version.

#### Which issue this PR fixes

- fixes #332 

#### Checklist

- [x ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x ] Chart Version bumped
- [x ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
