### PR TITLE
[jaeger-operator] Bump jaeger-operator to v1.30.0

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.27.1
-appVersion: 1.29.1
+version: 2.28.0
+appVersion: 1.30.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.29.1
+  tag: 1.30.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does
Update jaeger-operator to version v1.30.0

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
