### PR TITLE
[jaeger] support grpcPlugin environment variables

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.54.0
+version: 0.55.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -258,13 +258,33 @@ helm install jaeger jaegertracing/jaeger \
 
 #### Installing the Chart with Ingester using an existing Kafka Cluster
 
-You can use an exisiting Kafka cluster with jaeger too
+You can use an existing Kafka cluster with jaeger too
 
 ```console
 helm install jaeger jaegertracing/jaeger \
   --set ingester.enabled=true \
   --set storage.kafka.brokers={<BROKER1:PORT>,<BROKER2:PORT>} \
   --set storage.kafka.topic=<TOPIC>
+```
+
+### Other Storage Configuration
+
+If you are using grpc-plugin based storage, you can set environment
+variables that are needed by the plugin.
+
+As as example if using the [jaeger-mongodb](https://github.com/mongodb-labs/jaeger-mongodb)
+plugin you can set the `MONGO_URL` as follows...
+
+```YAML
+storage:
+  type: grpc-plugin
+  grpcPlugin:
+    extraEnv:
+      - name: MONGO_URL
+        valueFrom:
+          secretKeyRef:
+            key: MONGO_URL
+            name: jaeger-secrets
 ```
 
 ### All in One In-Memory Configuration
@@ -339,8 +359,8 @@ query:
 
 ## Installing extra kubernetes objects
 
-If additional kubernetes objects need to be installed alongside this chart, set the `extraObjects` array to contain 
-the yaml describing these objects. The values in the array are treated as a template to allow the use of variable 
+If additional kubernetes objects need to be installed alongside this chart, set the `extraObjects` array to contain
+the yaml describing these objects. The values in the array are treated as a template to allow the use of variable
 substitution and function calls as in the example below.
 
 Content of the `jaeger-values.yaml` file:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -373,13 +373,24 @@ Elasticsearch related environment variables
 {{- end -}}
 
 {{/*
-Cassandra or Elasticsearch related environment variables depending on which is used
+grpcPlugin related environment variables
+*/}}
+{{- define "grpcPlugin.env" -}}
+{{- if .Values.storage.grpcPlugin.extraEnv }}
+{{- toYaml .Values.storage.grpcPlugin.extraEnv }}
+{{- end }}
+{{- end -}}
+
+{{/*
+Cassandra, Elasticsearch, or grpc-plugin related environment variables depending on which is used
 */}}
 {{- define "storage.env" -}}
 {{- if eq .Values.storage.type "cassandra" -}}
 {{ include "cassandra.env" . }}
 {{- else if eq .Values.storage.type "elasticsearch" -}}
 {{ include "elasticsearch.env" . }}
+{{- else if eq .Values.storage.type "grpc-plugin" -}}
+{{ include "grpcPlugin.env" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -60,6 +60,9 @@ spec:
           {{- include "storage.cmdArgs" . | nindent 10 }}
           {{- end }}
         env:
+          {{- if .Values.collector.extraEnv }}
+            {{- toYaml .Values.collector.extraEnv | nindent 10 }}
+          {{- end }}
           {{- if .Values.collector.service.zipkin }}
           - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: {{ .Values.collector.service.zipkin.port | quote }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -89,6 +89,8 @@ storage:
     topic: jaeger_v1_test
     authentication: none
     extraEnv: []
+  grpcPlugin:
+    extraEnv: []
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger
 cassandra:
@@ -284,6 +286,7 @@ collector:
   imagePullSecrets: []
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
+  extraEnv: []
   cmdlineParams: {}
   replicaCount: 1
   autoscaling:


### PR DESCRIPTION
This PR adds support for being able to specify env variables for any grpc-plugin that's used. It also allows for specifying extra env for the collector just like the agent and query deployments allows.

I'm using the [jaeger-mongodb][1] with this updated chart as follows

```
storage:
  type: grpc-plugin
  grpcPlugin:
    extraEnv:
      - name: MONGO_URL
        valueFrom:
          secretKeyRef:
            key: MONGO_URL
            name: jaeger-secrets
```

which will render...

```
...
        env:
          - name: SPAN_STORAGE_TYPE
            value: grpc-plugin
          - name: MONGO_URL
            valueFrom:
              secretKeyRef:
                key: MONGO_URL
                name: jaeger-secrets
...

```

[1]:https://github.com/mongodb-labs/jaeger-mongodb

#### What this PR does

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
