### PR TITLE
chore: add task asking to update README.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -13,3 +13,4 @@ will close that issue when PR gets merged)*
 - [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
 - [ ] Chart Version bumped
 - [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
+- [ ] README.md has been updated to match version/contain new values


### PR DESCRIPTION
#### What this PR does

Add a task to remind folks to update README.md so i don't forget like i did in #342 

#### Which issue this PR fixes

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] ~Chart Version bumped~
- [x] ~Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)~
