### PR TITLE
[jaeger] Disable Jaeger allInOne ingress

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.0
+version: 0.56.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-ing.yaml
+++ b/charts/jaeger/templates/allinone-ing.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.allInOne.enabled -}}
+{{- if and (.Values.allInOne.enabled) (.Values.allInOne.ingress.enabled) -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -25,6 +25,8 @@ allInOne:
   #       "param": 1
   #     }
   #   }
+  ingress:
+    enabled: true
 
 
 storage:


### PR DESCRIPTION
#### What this PR does
Add `allInOne.ingress.enabled` property to values to be able to disable and override parent ingress.

#### Which issue this PR fixes
The default allInOne ingress use `defaultBackend` which leads to using `*` for the Ingress host which is not really convenient for usage.
<img width="468" alt="image" src="https://user-images.githubusercontent.com/31073930/164891354-ee49edc7-f0c9-48a9-b97b-88ae17e4ad7d.png">



#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
