### PR TITLE
[jaeger] Allow resources adjustment for allinone deployment

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.1
+version: 0.56.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -311,6 +311,19 @@ query:
   enabled: false
 ```
 
+It's possible to specify resources for the all in one deployment:
+
+```yaml
+allInOne:
+  resources:
+    limits:
+      cpu: 500m
+      memory: 512Mi
+    requests:
+      cpu: 256m
+      memory: 128Mi
+```
+
 ```bash
 helm install jaeger jaegertracing/jaeger --values values.yaml
 ```

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -73,6 +73,11 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
+      {{- with .Values.allInOne.resources }}
+          resources:
+        {{- toYaml . | nindent 12 }}
+      {{- end }}
+
         {{- if .Values.allInOne.samplingConfig}}
           volumeMounts:
             - name: strategies

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -27,6 +27,14 @@ allInOne:
   #   }
   ingress:
     enabled: true
+  # resources:
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
+  #   requests:
+  #     cpu: 256m
+  #     memory: 128Mi
+
 
 
 storage:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -35,8 +35,6 @@ allInOne:
   #     cpu: 256m
   #     memory: 128Mi
 
-
-
 storage:
   # allowed values (cassandra, elasticsearch)
   type: cassandra


### PR DESCRIPTION
Signed-off-by: guycarmy <guycarmy@gmail.com>

#### What this PR does
Allow specifying resources for all in one deployment.


#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [X] README.md has been updated to match version/contain new values
