### PR TITLE
[jaeger] Including optional extraEnv in allInOne

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.2
+version: 0.56.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -311,10 +311,13 @@ query:
   enabled: false
 ```
 
-It's possible to specify resources for the all in one deployment:
+It's possible to specify resources and extra environment variables for the all in one deployment:
 
 ```yaml
 allInOne:
+  extraEnv:
+    - name: QUERY_BASE_PATH
+      value: /jaeger
   resources:
     limits:
       cpu: 500m

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -27,6 +27,9 @@ spec:
     spec:
       containers:
         - env:
+          {{- if .Values.allInOne.extraEnv }}
+            {{- toYaml .Values.allInOne.extraEnv | nindent 12 }}
+          {{- end }}
             - name: SPAN_STORAGE_TYPE
               value: memory
             - name: COLLECTOR_ZIPKIN_HOST_PORT

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -18,6 +18,7 @@ allInOne:
   image: jaegertracing/all-in-one
   tag: 1.29.0
   pullPolicy: IfNotPresent
+  extraEnv: []
   # samplingConfig: |-
   #   {
   #     "default_strategy": {


### PR DESCRIPTION
Signed-off-by: Ueslei Lima <uesleisantoslima@gmail.com>

#### What this PR does
We have now more flexibility to include extra configuration via environment variables to the allInOne deployment.

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [X] README.md has been updated to match version/contain new values
