### PR TITLE
[jaeger] Add relabelings and metricRelabelings to serviceMonitors

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.4
+version: 0.56.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/agent-servicemonitor.yaml
+++ b/charts/jaeger/templates/agent-servicemonitor.yaml
@@ -26,6 +26,14 @@ spec:
       {{- if .Values.agent.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.agent.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.agent.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.agent.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.agent.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.agent.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/jaeger/templates/collector-servicemonitor.yaml
+++ b/charts/jaeger/templates/collector-servicemonitor.yaml
@@ -26,6 +26,14 @@ spec:
       {{- if .Values.collector.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.collector.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.collector.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.collector.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.collector.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.collector.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/jaeger/templates/ingester-servicemonitor.yaml
+++ b/charts/jaeger/templates/ingester-servicemonitor.yaml
@@ -26,6 +26,14 @@ spec:
       {{- if .Values.ingester.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.ingester.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.ingester.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.ingester.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.ingester.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.ingester.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/jaeger/templates/query-servicemonitor.yaml
+++ b/charts/jaeger/templates/query-servicemonitor.yaml
@@ -26,6 +26,14 @@ spec:
       {{- if .Values.query.serviceMonitor.scrapeTimeout }}
       scrapeTimeout: {{ .Values.query.serviceMonitor.scrapeTimeout }}
       {{- end }}
+      {{- if .Values.query.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml .Values.query.serviceMonitor.relabelings | nindent 8 }}
+      {{- end }}
+      {{- if .Values.query.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml .Values.query.serviceMonitor.metricRelabelings | nindent 8 }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -213,6 +213,11 @@ ingester:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    metricRelabelings: []
 
 agent:
   podSecurityContext: {}
@@ -284,6 +289,11 @@ agent:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    metricRelabelings: []
 
 collector:
   podSecurityContext: {}
@@ -411,6 +421,11 @@ collector:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    metricRelabelings: []
 
 query:
   enabled: true
@@ -521,6 +536,11 @@ query:
   serviceMonitor:
     enabled: false
     additionalLabels: {}
+    # https://github.com/prometheus-operator/prometheus-operator/blob/master/Documentation/api.md#relabelconfig
+    relabelings: []
+    # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
+    # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
+    metricRelabelings: []
   # config: |-
   #   {
   #     "dependencies": {


### PR DESCRIPTION
Signed-off-by: Ankit Mehta <ankit.mehta@appian.com>

#### What this PR does
Adds support for passing in relabeling and metricRelabelings from the chart values for the servicemonitors objects.

#### Which issue this PR fixes

- fixes #365 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
