### PR TITLE
[jaeger] Patch bitnami repository index

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.5
+version: 0.56.6
 keywords:
   - jaeger
   - opentracing
@@ -38,5 +38,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common
-    repository: https://charts.bitnami.com/bitnami
+    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
     version: 1.8.0

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -38,5 +38,5 @@ dependencies:
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common
-    repository: https://raw.githubusercontent.com/bitnami/charts/eb5f9a9513d987b519f0ecd732e7031241c50328/bitnami
-    version: 1.8.0
+    repository: https://charts.bitnami.com/bitnami
+    version: 1.16.0


### PR DESCRIPTION
Signed-off-by: czomo <tomaszjdul@gmail.com>

#### What this PR does
Set the backup of bitnami index after it has been clean up. See https://github.com/bitnami/charts/issues/10539 for more details
#### Which issue this PR fixes
It is impossible to build dependencies after bitnami clean up the index.

Steps to reproduce:
- Clone repo 
- Go to jaeger directory
- Execute `helm dependency build`

 Result:
```Downloading common from repo https://charts.bitnami.com/bitnami
Save error occurred:  could not find : chart common not found in https://charts.bitnami.com/bitnami
```
#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
