### PR TITLE
[jaeger-operator] Add compatibility matrix

### DIFF
--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -1,0 +1,20 @@
+The following table shows the compatibility of `Jaeger Operator helm chart` with different components, in this particular case we shows Jaeger Operator, Kubernetes and Strimzi operator compatibility. Cert-manager installed or certificate for webhook service in a secret is required in version 2.29.0+ of the helm chart.
+
+| Chart version          | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
+|------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.32.0(C), 2.32.1+     | v1.34.x         | v1.19 to v1.24  | v0.23              | v1.6.1+      |
+| (Missing)              | v1.33.x         | v1.19 to v1.23  | v0.23              | v1.6.1+      |
+| 2.30.0(C), 2.31.0(C)   | v1.32.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
+| 2.29.0(C)              | v1.31.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
+| 2.28.0                 | v1.30.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.27.1                 | v1.29.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.27.0                 | v1.28.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.26.0                 | v1.27.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)              | v1.26.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)              | v1.25.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.23.0, 2.24.0, 2.25.0 | v1.24.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)              | v1.23.x         | v1.19 to v1.21  | v0.19, v0.20       |              |
+| 2.21.*                 | v1.22.x         | v1.18 to v1.20  | v0.19              |              |
+Legend:
+- `(C)` Chart is corrupted. Please do not use it, see [link](https://github.com/jaegertracing/helm-charts/issues/351) and [link](https://github.com/jaegertracing/helm-charts/issues/373)
+- `(Missing)` Missing chart version for specified Jaeger Operator version

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.32.0
+version: 2.32.1
 appVersion: 1.34.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -17,7 +17,8 @@ This chart bootstraps a jaeger-operator deployment on a [Kubernetes](http://kube
 - Kubernetes 1.19+
 - cert-manager 1.6.1+ instaled 
 
-> **Caution**: Versions `2.28.0` and `2.29.0` are corrupted. Please do not use them, see [link](https://github.com/jaegertracing/helm-charts/issues/351)
+## Check compability matrix
+See the compatibility matrix [here](./COMPATIBILITY.md).
 
 ## Installing the Chart
 

--- a/charts/jaeger-operator/templates/NOTES.txt
+++ b/charts/jaeger-operator/templates/NOTES.txt
@@ -2,7 +2,7 @@ jaeger-operator is installed.
 
 
 Check the jaeger-operator logs
-  export POD=$(kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -lapp.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
+  export POD=$(kubectl get pods -l app.kubernetes.io/instance={{ .Release.Name }} -l app.kubernetes.io/name=jaeger-operator --namespace {{ .Release.Namespace }} --output name)
   kubectl logs $POD --namespace={{ .Release.Namespace }}
 
 


### PR DESCRIPTION
Signed-off-by: czomo <tomaszjdul@gmail.com>

#### What this PR does
Add compatibility matrix, better marking corrupted charts  
#### Which issue this PR fixes
- fixes #https://github.com/jaegertracing/helm-charts/pull/138

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
