### PR TITLE
[jaeger-operator] Refactor CRD to allow Jaeger CR creation on initial install

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.32.1
+version: 2.32.2
 appVersion: 1.34.1
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -15,7 +15,8 @@ This chart bootstraps a jaeger-operator deployment on a [Kubernetes](http://kube
 ## Prerequisites
 
 - Kubernetes 1.19+
-- cert-manager 1.6.1+ instaled 
+- Helm 3
+- cert-manager 1.6.1+ installed, or certificate for webhook service in a secret
 
 ## Check compability matrix
 See the compatibility matrix [here](./COMPATIBILITY.md).
@@ -60,7 +61,6 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |
-| `crd.install`           | CustomResourceDefinition will be installed                                                                  | `true`                          |
 | `rbac.create`           | All required roles and rolebindings will be created                                                         | `true`                          |
 | `serviceAccount.create` | Service account to use                                                                                      | `true`                          |
 | `rbac.pspEnabled`       | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
@@ -81,6 +81,13 @@ You can also specify any non-array parameter using the `--set key=value[,key=val
 ```console
 $ helm install jaegertracing/jaeger-operator --name my-release \
     --set rbac.create=false
+```
+
+To install the chart without creating the CRDs (any files under `chart/crds`) make use of the `--skip-crds` flag. For example,
+
+```console
+$ helm install jaegertracing/jaeger-operator --name my-release \
+    --skip-crds
 ```
 
 ## After the Helm Installation

--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -2,10 +2,9 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: jaegers.jaegertracing.io
-  annotations:
-    cert-manager.io/inject-ca-from: {{ default {{ .Release.Namespace }} .Values.certs.certificate.namespace }}/{{ default "jaeger-operator-service-cert" .Values.certs.certificate.secretName }}
   labels:
-{{ include "jaeger-operator.labels" . | indent 4 }}
+    app.kubernetes.io/name: jaeger-operator
+    app.kubernetes.io/instance: jaeger-operator
 spec:
   group: jaegertracing.io
   names:

--- a/charts/jaeger-operator/templates/crds.yaml
+++ b/charts/jaeger-operator/templates/crds.yaml
@@ -1,6 +1,0 @@
-{{- if .Values.crd.install }}
-{{- range $path, $bytes := .Files.Glob "crds/*.yaml" }}
-{{ $.Files.Get $path }}
----
-{{- end }}
-{{- end }}

--- a/charts/jaeger-operator/templates/validating-webhook.yaml
+++ b/charts/jaeger-operator/templates/validating-webhook.yaml
@@ -1,4 +1,4 @@
-{{- if and (.Values.webhooks.mutatingWebhook.create) (.Values.webhooks.service.create) }}
+{{- if and (.Values.webhooks.validatingWebhook.create) (.Values.webhooks.service.create) }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -8,9 +8,6 @@ image:
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 
-crd:
-  install: true
-
 certs:
   issuer:
     create: true


### PR DESCRIPTION
Signed-off-by: Micah Nagel <micah.nagel@parsons.com>

#### What this PR does

https://github.com/jaegertracing/helm-charts/pull/368 moved the CRD out of the special `chart/crds` helm chart folder and into `chart/crd`. While this did result in the chart making use of the already existing `chart/templates/crd.yaml` template to install the CRD, the other result is that you must install the helm chart without `jaeger.create` set to true, then upgrade after the CRD has been installed. If we make use of the `chart/crds` folder as recommended by the first method [here](https://helm.sh/docs/chart_best_practices/custom_resource_definitions/#method-1-let-helm-do-it-for-you) then the CRDs are installed before Helm applies the other manifests.

This unknowingly introduced what I would consider a breaking change into the chart - you now are required to install the operator separately from the `Jaeger` CR (install then upgrade).

Fixes https://github.com/jaegertracing/helm-charts/issues/373

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
