### PR TITLE
[jaeger] Custom labels in query and collector ingresses

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.30.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.56.7
+version: 0.56.8
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ template "jaeger.collector.name" . }}
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
+    {{- if .Values.collector.ingress.labels }}
+    {{- toYaml .Values.collector.ingress.labels | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/component: collector
   {{- if .Values.collector.ingress.annotations }}
   annotations:

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -8,6 +8,9 @@ metadata:
   name: {{ template "jaeger.query.name" . }}
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
+    {{- if .Values.query.ingress.labels }}
+    {{- toYaml .Values.query.ingress.labels | nindent 4 }}
+    {{- end }}
     app.kubernetes.io/component: query
   {{- if .Values.query.ingress.annotations }}
   annotations:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -338,6 +338,7 @@ collector:
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
     annotations: {}
+    labels: {}
     # Used to create an Ingress record.
     # The 'hosts' variable accepts two formats:
     # hosts:
@@ -349,6 +350,8 @@ collector:
     # annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    # labels:
+      # app: jaeger-collector  
     # tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls
@@ -486,12 +489,15 @@ query:
     # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
     # ingressClassName: nginx
     annotations: {}
+    labels: {}
     # Used to create an Ingress record.
     # hosts:
     #   - chart-example.local
     # annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
+    # labels:
+      # app: jaeger-query  
     # tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -351,7 +351,7 @@ collector:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger-collector  
+      # app: jaeger-collector
     # tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls
@@ -497,7 +497,7 @@ query:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger-query  
+      # app: jaeger-query
     # tls:
       # Secrets must be manually created in the namespace.
       # - secretName: chart-example-tls


### PR DESCRIPTION
Signed-off-by: Nicolas <nicorabatel@gmail.com>

#### What this PR does
Adding values to be able to add custom labels in query and collector ingresses


#### Which issue this PR fixes


- fixes  https://github.com/jaegertracing/helm-charts/issues/104

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
~- [ ] README.md has been updated to match version/contain new values~
