### PR TITLE
[jaeger-operator] Update to Jaeger Operator 1.35.0

### DIFF
--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -1,20 +1,21 @@
 The following table shows the compatibility of `Jaeger Operator helm chart` with different components, in this particular case we shows Jaeger Operator, Kubernetes and Strimzi operator compatibility. Cert-manager installed or certificate for webhook service in a secret is required in version 2.29.0+ of the helm chart.
 
-| Chart version          | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
-|------------------------|-----------------|-----------------|--------------------|--------------|
-| 2.32.0(C), 2.32.1+     | v1.34.x         | v1.19 to v1.24  | v0.23              | v1.6.1+      |
-| (Missing)              | v1.33.x         | v1.19 to v1.23  | v0.23              | v1.6.1+      |
-| 2.30.0(C), 2.31.0(C)   | v1.32.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
-| 2.29.0(C)              | v1.31.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
-| 2.28.0                 | v1.30.x         | v1.19 to v1.21  | v0.23              |              |
-| 2.27.1                 | v1.29.x         | v1.19 to v1.21  | v0.23              |              |
-| 2.27.0                 | v1.28.x         | v1.19 to v1.21  | v0.23              |              |
-| 2.26.0                 | v1.27.x         | v1.19 to v1.21  | v0.23              |              |
-| (Missing)              | v1.26.x         | v1.19 to v1.21  | v0.23              |              |
-| (Missing)              | v1.25.x         | v1.19 to v1.21  | v0.23              |              |
-| 2.23.0, 2.24.0, 2.25.0 | v1.24.x         | v1.19 to v1.21  | v0.23              |              |
-| (Missing)              | v1.23.x         | v1.19 to v1.21  | v0.19, v0.20       |              |
-| 2.21.*                 | v1.22.x         | v1.18 to v1.20  | v0.19              |              |
+| Chart version             | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
+|---------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.33.0                    | v1.35.x         | v1.19 to v1.24  | v0.23              | v1.6.1+      |
+| 2.32.0(C), 2.32.1, 2.32.2 | v1.34.x         | v1.19 to v1.24  | v0.23              | v1.6.1+      |
+| (Missing)                 | v1.33.x         | v1.19 to v1.23  | v0.23              | v1.6.1+      |
+| 2.30.0(C), 2.31.0(C)      | v1.32.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
+| 2.29.0(C)                 | v1.31.x         | v1.19 to v1.21  | v0.23              | v1.6.1+      |
+| 2.28.0                    | v1.30.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.27.1                    | v1.29.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.27.0                    | v1.28.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.26.0                    | v1.27.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)                 | v1.26.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)                 | v1.25.x         | v1.19 to v1.21  | v0.23              |              |
+| 2.23.0, 2.24.0, 2.25.0    | v1.24.x         | v1.19 to v1.21  | v0.23              |              |
+| (Missing)                 | v1.23.x         | v1.19 to v1.21  | v0.19, v0.20       |              |
+| 2.21.*                    | v1.22.x         | v1.18 to v1.20  | v0.19              |              |
 Legend:
 - `(C)` Chart is corrupted. Please do not use it, see [link](https://github.com/jaegertracing/helm-charts/issues/351) and [link](https://github.com/jaegertracing/helm-charts/issues/373)
 - `(Missing)` Missing chart version for specified Jaeger Operator version

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.32.2
-appVersion: 1.34.1
+version: 2.33.0
+appVersion: 1.35.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -57,7 +57,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
 | `extraLabels`           | Additional labels to jaeger-operator deployment  | `{}`
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.34.1`                        |
+| `image.tag`             | Controller container image tag                                                                              | `1.35.0`                        |
 | `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/crds/crd.yaml
+++ b/charts/jaeger-operator/crds/crd.yaml
@@ -3290,6 +3290,8 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  kafkaSecretName:
+                    type: string
                   labels:
                     additionalProperties:
                       type: string
@@ -4539,6 +4541,8 @@ spec:
                       type: object
                     type: array
                     x-kubernetes-list-type: atomic
+                  kafkaSecretName:
+                    type: string
                   labels:
                     additionalProperties:
                       type: string

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -22,7 +22,6 @@ spec:
     app.kubernetes.io/name: {{ include "jaeger-operator.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
   type: {{ .Values.service.type }}
-
 ---
 {{- if .Values.webhooks.service.create }}
 apiVersion: v1

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.34.1
+  tag: 1.35.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

Updates to Jaeger Operator 1.35.0: Update chart version, appversion, image tag, CRD, compatibility table.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
