### PR TITLE
[jaeger] Add *_USER to the environment only if usePassword is true

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.36.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.57.0
+version: 0.57.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -350,9 +350,9 @@ Elasticsearch related environment variables
 {{- define "elasticsearch.env" -}}
 - name: ES_SERVER_URLS
   value: {{ include "elasticsearch.client.url" . }}
+{{- if .Values.storage.elasticsearch.usePassword }}
 - name: ES_USERNAME
   value: {{ .Values.storage.elasticsearch.user }}
-{{- if .Values.storage.elasticsearch.usePassword }}
 - name: ES_PASSWORD
   valueFrom:
     secretKeyRef:


### PR DESCRIPTION
Signed-off-by: Abubakr-Sadik Nii Nai Davis <dwa2pac@gmail.com>

#### What this PR does

Fixes a situation where jaeger helm install fails because ES_USER is set without setting ES_PASSWORD.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
