### PR TITLE
[jaeger] Enable the OTLP receiver

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.36.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.57.0
+version: 0.57.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -67,6 +67,18 @@ spec:
           - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: {{ .Values.collector.service.zipkin.port | quote }}
           {{- end }}
+          {{- if or .Values.collector.service.otlp.grpc .Values.collector.service.otlp.http }}
+          - name: COLLECTOR_OTLP_ENABLED
+            value: "true"
+          {{- end }}
+          {{- if ne (default 4317 .Values.collector.service.otlp.grpc.port | toString ) "4317" }}
+          - name: COLLECTOR_OTLP_GRPC_HOST_PORT
+            value: {{ .Values.collector.service.otlp.grpc.port | quote }}
+          {{- end }}
+          {{- if ne (default 4318 .Values.collector.service.otlp.http.port | toString) "4318" }}
+          - name: COLLECTOR_OTLP_HTTP_HOST_PORT
+            value: {{ .Values.collector.service.otlp.http.port | quote }}
+          {{- end }}
           {{- if .Values.ingester.enabled }}
           - name: SPAN_STORAGE_TYPE
             value: kafka
@@ -105,6 +117,14 @@ spec:
         {{- if .Values.collector.service.zipkin }}
         - containerPort: {{ .Values.collector.service.zipkin.port }}
           name: zipkin
+          protocol: TCP
+        {{- end }}
+        {{- if or .Values.collector.service.otlp.grpc .Values.collector.service.otlp.http }}
+        - containerPort: {{ default 4317 .Values.collector.service.otlp.grpc.port }}
+          name: otlp-grpc
+          protocol: TCP
+        - containerPort: {{ default 4318 .Values.collector.service.otlp.http.port }}
+          name: otlp-http
           protocol: TCP
         {{- end }}
         readinessProbe:

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -35,6 +35,22 @@ spec:
     protocol: TCP
     targetPort: zipkin
 {{- end }}
+{{- if or .Values.collector.service.otlp.grpc .Values.collector.service.otlp.http }}
+  - name: otlp-grpc
+    port: {{ default 4317 .Values.collector.service.otlp.grpc.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.otlp.grpc.nodePort) }}
+    nodePort: {{ .Values.collector.service.otlp.grpc.nodePort }}
+{{- end }}
+    protocol: TCP
+    targetPort: otlp-grpc
+  - name: otlp-http
+    port: {{ default 4318 .Values.collector.service.otlp.http.port }}
+{{- if and (eq .Values.collector.service.type "NodePort") (.Values.collector.service.otlp.http.nodePort) }}
+    nodePort: {{ .Values.collector.service.otlp.http.nodePort }}
+{{- end }}
+    protocol: TCP
+    targetPort: otlp-http
+{{- end }}
   - name: admin
     port: 14269
     targetPort: admin

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -332,6 +332,13 @@ collector:
     zipkin: {}
       # port: 9411
       # nodePort:
+    otlp:
+      grpc: {}
+        # port: 4317
+        # nodePort:
+      http: {}
+        # port: 4318
+        # nodePort:
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName


### PR DESCRIPTION
Signed-off-by: Tiago Angelo <kurtis.angelo@gmail.com>

#### What this PR does

Adds the ability to enable Collector to receive trace data via OTLP also allows changing the default ports.

#### Which issue this PR fixes

- fixes #382 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
