### PR TITLE
[jaeger] feat: add option to add "envFrom" in deployments

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.6
+version: 0.71.7
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -66,6 +66,10 @@ spec:
           - name: REPORTER_GRPC_HOST_PORT
             value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
+      {{- with .Values.agent.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 10 }}
+      {{- end }}
         ports:
         - name: zipkin-compact
           containerPort: {{ .Values.agent.service.zipkinThriftPort }}

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -45,6 +45,10 @@ spec:
             - name: SAMPLING_STRATEGIES_FILE
               value: /etc/conf/strategies.json
             {{- end }}
+        {{- with .Values.allInOne.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
           image: {{ .Values.allInOne.image }}:{{- .Values.allInOne.tag | default (include "jaeger.image.tag" .) }}
           imagePullPolicy: {{ .Values.allInOne.pullPolicy }}
           name: jaeger

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -102,6 +102,10 @@ spec:
           - name: SAMPLING_STRATEGIES_FILE
             value: /etc/conf/strategies.json
           {{- end }}
+      {{- with .Values.collector.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 12 }}
+      {{- end }}
         ports:
         - containerPort: {{ .Values.collector.service.grpc.port }}
           name: grpc

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -78,6 +78,10 @@ spec:
           - name: KAFKA_CONSUMER_AUTHENTICATION
             value: {{ .Values.storage.kafka.authentication }}
           {{- end }}
+      {{- with .Values.ingester.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 12 }}
+      {{- end }}
         ports:
         - containerPort: 14270
           name: admin

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -70,6 +70,10 @@ spec:
           - name: QUERY_UI_CONFIG
             value: /etc/conf/query-ui-config.json
           {{- end }}
+      {{- with .Values.query.envFrom }}
+        envFrom:
+          {{- toYaml . | nindent 12 }}
+      {{- end }}
         ports:
         - name: query
           containerPort: 16686

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -250,6 +250,7 @@ ingester:
   podLabels: {}
   extraSecretMounts: []
   extraConfigmapMounts: []
+  envFrom: []
 
   serviceMonitor:
     enabled: false
@@ -322,6 +323,7 @@ agent:
   #   subPath: ""
   #   configMap: jaeger-config
   #   readOnly: true
+  envFrom: []
   useHostNetwork: false
   dnsPolicy: ClusterFirst
   priorityClassName: ""
@@ -347,6 +349,7 @@ collector:
   pullPolicy: IfNotPresent
   dnsPolicy: ClusterFirst
   extraEnv: []
+  envFrom: []
   cmdlineParams: {}
   basePath: /
   replicaCount: 1
@@ -539,6 +542,7 @@ query:
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   extraEnv: []
+  envFrom: []
   replicaCount: 1
   service:
     annotations: {}


### PR DESCRIPTION
#### What this PR does

This PR adds an option of giving "envFrom" to the deployment manifest. 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values (> not sure where to update new version in the readme)
