### PR TITLE
[jaeger] chore: bumping Kafka chart version to ^18.0.8

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^15.5.1
+    version: ^18.0.8
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -34,7 +34,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^14.9.1
+    version: ^15.5.1
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.58.0
+version: 0.59.0
 keywords:
   - jaeger
   - opentracing


### PR DESCRIPTION
Signed-off-by: Loc Mai <locmai0201@gmail.com>

#### What this PR does

Upgrade Kafka chart to ^18.0.8 which contains the next major version of Kafka from 2.8 to 3.2.0

#### Which issue this PR fixes

- fixes  #352

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values

#### Additional notes about the Kafka upgrade

I was able to upgrade the Kafka without causing any side effect for Jaeger. And the tracing spans could flow in normally after the upgrade.

Take the guidance from Kafka into account, we could also update the document to set the server.properties right, note that I didn't take these steps, a simple version bump solve the case.

1. Add an upgrading section for major version from Kafka
2. Add the `inter.broker.protocol.version=<current-version-to-upgrade-from>` (latest: inter.broker.protocol.version=2.8.1) into the Kafka config section.
3. Apply the change
4. After rolling out all of the Kafka pods, remove the `inter.broker.protocol.version` line or set it to the one we just upgraded from (inter.broker.protocol.version=3.1.0)

Testing values:

```yaml
provisionDataStore:
  cassandra: false
  elasticsearch: true
  kafka: true

storage:
  type: elasticsearch

kafka:
  replicaCount: 3
  autoCreateTopicsEnable: true
  zookeeper:
    replicaCount: 3
    serviceAccount:
      create: true
```

I actually tested from ^14.9.1 to ^15.5.1  and it works. Being greedy and bump it to ^18.0.8 still works with no breaking change/downtime.

Test video: https://www.youtube.com/watch?v=JQYUb0LUjds


---
# Upgrading notes

## Kafka
### To 15.0.0
> This major release bumps Kafka major version to 3.x series. It also renames several values in this chart and adds missing features, in order to be inline with the rest of assets in the Bitnami charts repository. Some affected values are:
> - service.port, service.internalPort and service.externalPort have been regrouped under the service.ports map.
> - metrics.kafka.service.port has been regrouped under the metrics.kafka.service.ports map.> 
> - metrics.jmx.service.port has been regrouped under the metrics.jmx.service.ports map.
> - updateStrategy (string) and rollingUpdatePartition are regrouped under the updateStrategy map.
> - Several parameters marked as deprecated 14.x.x are not supported anymore.

Since by default, we don't override these values - [ref](https://github.com/jaegertracing/helm-charts/blob/3a4bc37924716661f4198a3c95c691ca50318e5e/charts/jaeger/values.yaml#L117-L124) - we don't need to do anything for it.

From 15.0.0 -> 16.0.0 -> 18.0.0, we have the upgrades for Zookeeper Helm chart which doesn't contain any breaking change.

For example:

### To 16.0.0

This major updates the Zookeeper subchart to it newest major, 9.0.0. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-900).

### To 18.0.0

This major updates the Zookeeper subchart to it newest major, 10.0.0. For more information on this subchart's major, please refer to [zookeeper upgrade notes](https://github.com/bitnami/charts/tree/master/bitnami/zookeeper#to-1000).

## Zookeeper

Pretty much the same for the values - and since we didn't touch much for the default one, we are safe:

### To 8.0.0

> Affected values:
> allowAnonymousLogin is deprecated.
> - containerPort, tlsContainerPort, followerContainerPort and electionContainerPort have been regrouped under the containerPorts map.
> - service.port, service.tlsClientPort, service.followerPort, and service.electionPort have been regrouped under the service.ports map.
> - updateStrategy (string) and rollingUpdatePartition are regrouped under the updateStrategy map.
> - podDisruptionBudget.* parameters are renamed to pdb.*.

### To 10.0.0

> This new version of the chart adds support for server-server authentication. The chart previously supported client-server authentication, to avioud confusion, the previous parameters have been renamed from auth.* to auth.client.*.