### PR TITLE
[jaeger] Add ttlSecondsAfterFinished entry to esIndexCleaner job

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.59.0
+version: 0.60.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -21,6 +21,9 @@ spec:
       {{- if .Values.esIndexCleaner.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.esIndexCleaner.activeDeadlineSeconds }}
       {{- end }}
+      {{- if .Values.esIndexCleaner.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.esIndexCleaner.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esIndexCleaner.podAnnotations }}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -21,6 +21,9 @@ spec:
       {{- if .Values.esLookback.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.esLookback.activeDeadlineSeconds }}
       {{- end }}
+      {{- if .Values.esLookback.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.esLookback.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esLookback.podAnnotations }}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -21,6 +21,9 @@ spec:
       {{- if .Values.esRollover.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.esRollover.activeDeadlineSeconds }}
       {{- end }}
+      {{- if .Values.esRollover.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.esRollover.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.esRollover.podAnnotations }}

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -20,6 +20,9 @@ spec:
       {{- if .Values.spark.activeDeadlineSeconds }}
       activeDeadlineSeconds: {{ .Values.spark.activeDeadlineSeconds }}
       {{- end}}
+      {{- if .Values.spark.ttlSecondsAfterFinished }}
+      ttlSecondsAfterFinished: {{ .Values.spark.ttlSecondsAfterFinished }}
+      {{- end }}
       template:
         metadata:
           {{- if .Values.spark.podAnnotations }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -601,6 +601,7 @@ spark:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  # ttlSecondsAfterFinished: 120
 
 esIndexCleaner:
   enabled: false
@@ -642,6 +643,7 @@ esIndexCleaner:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  # ttlSecondsAfterFinished: 120
 
 esRollover:
   enabled: false
@@ -682,6 +684,7 @@ esRollover:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  # ttlSecondsAfterFinished: 120
   initHook:
     extraEnv: []
       # - name: SHARDS
@@ -732,6 +735,7 @@ esLookback:
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
+  # ttlSecondsAfterFinished: 120
 # End: Default values for the various components of Jaeger
 
 hotrod:


### PR DESCRIPTION
Add ttlSecondsAfterFinished entry to esIndexCleaner for removing completed jobs of the ElasticSearch Index Cleaner after the configured amount of time

#### What this PR does

Make ttlSecondsAfterFinished for esIndexCleaner configurable

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #393

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
