### PR TITLE
[jaeger] OpenTelemetry Protocol (OTLP) enabled on Jaeger All-in-one

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.60.0
+version: 0.61.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-collector-svc.yaml
+++ b/charts/jaeger/templates/allinone-collector-svc.yaml
@@ -21,6 +21,12 @@ spec:
     - name: http-c-binary-trft
       port: 14268
       targetPort: 0
+    - name: otlp-grpc
+      port: 4317
+      targetPort: 0
+    - name: otlp-http
+      port: 4318
+      targetPort: 0
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: all-in-one

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -36,6 +36,8 @@ spec:
               value: :9411
             - name: JAEGER_DISABLED
               value: "false"
+            - name: COLLECTOR_OTLP_ENABLED
+              value: "true"
             {{- if .Values.allInOne.samplingConfig }}
             - name: SAMPLING_STRATEGIES_FILE
               value: /etc/conf/strategies.json
@@ -55,6 +57,10 @@ spec:
             - containerPort: 16686
               protocol: TCP
             - containerPort: 9411
+              protocol: TCP
+            - containerPort: 4317
+              protocol: TCP
+            - containerPort: 4318
               protocol: TCP
           livenessProbe:
             failureThreshold: 5

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -16,7 +16,6 @@ fullnameOverride: ""
 allInOne:
   enabled: false
   image: jaegertracing/all-in-one
-  tag: 1.29.0
   pullPolicy: IfNotPresent
   extraEnv: []
   # samplingConfig: |-


### PR DESCRIPTION
#### What this PR does

Enables the native support for OpenTelemetry in Jaeger All-in-one

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
