### PR TITLE
[jaeger] Fix sidecar indentation

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.61.0
+version: 0.62.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -216,7 +216,7 @@ spec:
             port: admin
 {{- end }}
       {{- if .Values.query.sidecars }}
-        {{- tpl (toYaml .Values.query.sidecars) . | nindent 8 }}
+        {{- tpl (toYaml .Values.query.sidecars) . | nindent 6 }}
       {{- end }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always


### PR DESCRIPTION
Signed-off-by: Tiago Angelo <kurtis.angelo@gmail.com>

#### What this PR does

It fixes a wrong indent that made it impossible to configure custom sidecars

#### Which issue this PR fixes

- fixes #402

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
