### PR TITLE
[Jaeger] - Feature - Added NodeSelector for All in One Image.

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.62.0
+version: 0.62.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -99,4 +99,8 @@ spec:
           configMap:
             name: {{ include "jaeger.fullname" . }}-sampling-strategies
     {{- end }}
+    {{- with .Values.allInOne.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -34,6 +34,7 @@ allInOne:
   #   requests:
   #     cpu: 256m
   #     memory: 128Mi
+  nodeSelector: {}
 
 storage:
   # allowed values (cassandra, elasticsearch)


### PR DESCRIPTION
Signed-off-by: Ramazan Kara <ramazan.kara@otto.de>
Co-authored-by: Otto Wagner <otto.wagner@otto.de>

#### What this PR does

We have added the NodeSelector for the All in One Image and would like this feature to be integrated into the Jaegertracing Helm Charts.

#### Which issue this PR fixes

Previously, there was no NodeSelector for the all in one Image so there was no way of deploying the AllinOne Image across multiple NodeGroups into a selected Nodegroup. This PR fixes this and allows the Image to be deployed to a specific Nodegroup.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
