### PR TITLE
[jaeger] Add podLabels and complete ingress

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.62.1
+version: 0.62.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.62.2
+version: 0.64.0
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -21,6 +21,9 @@ spec:
       labels:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: all-in-one
+{{- if .Values.allInOne.podLabels }}
+        {{- toYaml .Values.allInOne.podLabels | nindent 8 }}
+{{- end }}
       annotations:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"

--- a/charts/jaeger/templates/allinone-ing.yaml
+++ b/charts/jaeger/templates/allinone-ing.yaml
@@ -1,4 +1,5 @@
 {{- if and (.Values.allInOne.enabled) (.Values.allInOne.ingress.enabled) -}}
+{{- $ingressSupportsIngressClassName := eq (include "common.ingress.supportsIngressClassname" .) "true" }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -6,10 +7,27 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: all-in-one
+  {{- if .Values.allInOne.ingress.annotations }}
+  annotations:
+    {{- toYaml .Values.allInOne.ingress.annotations | nindent 4 }}
+  {{- end }}
 spec:
-  defaultBackend:
-    service:
-      name: {{ template "jaeger.query.name" . }}
-      port:
-        number: 16686
+  {{- if and $ingressSupportsIngressClassName .Values.allInOne.ingress.ingressClassName }}
+  ingressClassName: {{ .Values.allInOne.ingress.ingressClassName }}
+  {{- end }}
+  rules:
+    {{- range $host := .Values.allInOne.ingress.hosts }}
+    - host: {{ $host }}
+      http:
+        paths:
+          - path: /
+            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
+            pathType: ImplementationSpecific
+            {{- end }}
+            backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16686 "context" $) | nindent 14 }}
+  {{- end -}}
+  {{- if .Values.allInOne.ingress.tls }}
+  tls:
+  {{- toYaml .Values.allInOne.ingress.tls | nindent 4 }}
+  {{- end -}}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -26,7 +26,25 @@ allInOne:
   #     }
   #   }
   ingress:
-    enabled: true
+    enabled: false
+    # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
+    # See https://kubernetes.io/blog/2020/04/02/improvements-to-the-ingress-api-in-kubernetes-1.18/#specifying-the-class-of-an-ingress
+    # ingressClassName: nginx
+    annotations: {}
+    labels: {}
+    # Used to create an Ingress record.
+    # hosts:
+    #   - chart-example.local
+    # annotations:
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
+    # labels:
+      # app: jaeger
+    # tls:
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
   # resources:
   #   limits:
   #     cpu: 500m

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -370,8 +370,8 @@ collector:
     #   - chart-example.local
     # or:
     # hosts:
-      # - host: chart-example.local
-      #   servicePort: grpc
+    #   - host: chart-example.local
+    #     servicePort: grpc
     # annotations:
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -373,15 +373,15 @@ collector:
     #   - host: chart-example.local
     #     servicePort: grpc
     # annotations:
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger-collector
+    #   app: jaeger-collector
     # tls:
-      # Secrets must be manually created in the namespace.
-      # - secretName: chart-example-tls
-      #   hosts:
-      #     - chart-example.local
+    #   # Secrets must be manually created in the namespace.
+    #   - secretName: chart-example-tls
+    #     hosts:
+    #       - chart-example.local
   resources: {}
     # limits:
     #   cpu: 1

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -36,15 +36,15 @@ allInOne:
     # hosts:
     #   - chart-example.local
     # annotations:
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    #   kubernetes.io/ingress.class: nginx
+    #   kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger
+    #   app: jaeger
     # tls:
-      # Secrets must be manually created in the namespace.
-      # - secretName: chart-example-tls
-      #   hosts:
-      #     - chart-example.local
+    #   # Secrets must be manually created in the namespace.
+    #   - secretName: chart-example-tls
+    #     hosts:
+    #       - chart-example.local
   # resources:
   #   limits:
   #     cpu: 500m
@@ -370,18 +370,18 @@ collector:
     #   - chart-example.local
     # or:
     # hosts:
-    #   - host: chart-example.local
-    #     servicePort: grpc
+      # - host: chart-example.local
+      #   servicePort: grpc
     # annotations:
-    #   kubernetes.io/ingress.class: nginx
-    #   kubernetes.io/tls-acme: "true"
+      # kubernetes.io/ingress.class: nginx
+      # kubernetes.io/tls-acme: "true"
     # labels:
-    #   app: jaeger-collector
+      # app: jaeger-collector
     # tls:
-    #   # Secrets must be manually created in the namespace.
-    #   - secretName: chart-example-tls
-    #     hosts:
-    #       - chart-example.local
+      # Secrets must be manually created in the namespace.
+      # - secretName: chart-example-tls
+      #   hosts:
+      #     - chart-example.local
   resources: {}
     # limits:
     #   cpu: 1


### PR DESCRIPTION
Signed-off-by: Petrus.Z <silencly07@gmail.com>

#### What this PR does

Add `values.allInOne.podLabels`property to values, and complete the allInOne ingress, thus disable ingress by default.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
