### PR TITLE
[jaeger] bumping chart & opening up 16685 port

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.64.0
+version: 0.64.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -59,6 +59,8 @@ spec:
               protocol: TCP
             - containerPort: 16686
               protocol: TCP
+            - containerPort: 16685
+              protocol: TCP
             - containerPort: 9411
               protocol: TCP
             - containerPort: 4317


### PR DESCRIPTION
Signed-off-by: palmheads <daz@planetnz.com>

#### What this PR does
When using the all-in-one jaeger deploy with helm, opens up port 16685 which currently gets a connection refused
#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #3852

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
