### PR TITLE
[jaeger] - add args to allinone

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.64.1
+version: 0.64.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -48,6 +48,10 @@ spec:
           image: {{ .Values.allInOne.image }}:{{- .Values.allInOne.tag | default (include "jaeger.image.tag" .) }}
           imagePullPolicy: {{ .Values.allInOne.pullPolicy }}
           name: jaeger
+          args:
+            {{- range $arg := .Values.allInOne.args }}
+            - "{{ $arg }}"
+            {{- end }}
           ports:
             - containerPort: 5775
               protocol: UDP

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -18,6 +18,9 @@ allInOne:
   image: jaegertracing/all-in-one
   pullPolicy: IfNotPresent
   extraEnv: []
+  # command line arguments / CLI flags
+  # See https://www.jaegertracing.io/docs/cli/
+  args: []
   # samplingConfig: |-
   #   {
   #     "default_strategy": {


### PR DESCRIPTION
Signed-off-by: Pierre Tessier <pierre@pierretessier.com>

#### What this PR does

Adds the ability to specify args for the All in one mode.

#### Which issue this PR fixes

This helps unblock [Issue #515 with the OpenTelemetry Demo Helm chart](https://github.com/open-telemetry/opentelemetry-helm-charts/issues/515)

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
