### PR TITLE
adding strategyType support for collector pods

### DIFF
--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -14,6 +14,14 @@ spec:
 {{- if not .Values.collector.autoscaling.enabled }}
   replicas: {{ .Values.collector.replicaCount }}
 {{- end }}
+  strategy:
+    type: {{ .Values.collector.strategy.type }}
+    {{- if eq .Values.collector.strategy.type "RollingUpdate" }}
+    rollingUpdate:
+      maxSurge: {{ .Values.collector.strategy.type.rollingUpdate.maxSurge }}
+      maxUnavailable: {{ .Values.collector.strategy.type.rollingUpdate.maxUnavailable }}
+    {{- end }}
+
   selector:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -335,6 +335,11 @@ collector:
     maxReplicas: 10
     # targetCPUUtilizationPercentage: 80
     # targetMemoryUtilizationPercentage: 80
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   service:
     annotations: {}
     # The IP to be used by the load balancer (if supported)


### PR DESCRIPTION
#### What this PR does
-> This PR adds deployment strategyType of "RollingUpdate" rather than Recreate which is causing downtime whilst at the time of deployment.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
