### PR TITLE
[jaeger-operator] will allow to change webhook and metrics ports

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.37.0
+version: 2.38.0
 appVersion: 1.39.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -38,14 +38,17 @@ spec:
         - name: {{ . }}
       {{- end }}
       {{- end }}
+      {{- if .Values.hostNetwork }}
+      hostNetwork: {{ .Values.hostNetwork }}
+      {{- end }}
       containers:
         - name: {{ include "jaeger-operator.fullname" . }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
-          - containerPort: 8383
+          - containerPort: {{ .Values.metricsPort }}
             name: metrics
-          - containerPort: 9443
+          - containerPort: {{ .Values.webhooks.port }}
             name: webhook-server
             protocol: TCP  
           volumeMounts:

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -12,9 +12,9 @@ metadata:
 spec:
   ports:
   - name: metrics
-    port: 8383
+    port: {{ .Values.metricsPort }}
     protocol: TCP
-    targetPort: 8383
+    targetPort: {{ .Values.metricsPort }}
 {{- if and (eq .Values.service.type "NodePort") (.Values.service.nodePort) }}
     nodePort: {{ .Values.service.nodePort }}
 {{- end }}
@@ -39,7 +39,7 @@ spec:
   ports:
   - port: 443
     protocol: TCP
-    targetPort: 9443
+    targetPort: {{ .Values.webhooks.port }}
   selector:
 {{ include "jaeger-operator.labels" . | indent 4 }}
 {{- end }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -22,6 +22,7 @@ webhooks:
     create: true
   validatingWebhook:
     create: true
+  port: 9443
   service:
     annotations: {}
     create: true
@@ -83,3 +84,8 @@ affinity: {}
 securityContext: {}
 
 priorityClassName:
+
+# Specifies weather host network should be used
+hostNetwork: false
+
+metricsPort: 8383


### PR DESCRIPTION
#### What this PR does

Changes in this PR allow for modifying default webhook and metrics ports.
This is directly related to below two PR's

- [jaeger-operator](https://github.com/jaegertracing/jaeger-operator/pull/1991)
- [documentation](https://github.com/jaegertracing/documentation/pull/582)

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
