### PR TITLE
[jaeger] fix (query,collector) basePath

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.65.2
+version: 0.65.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -328,6 +328,7 @@ collector:
   dnsPolicy: ClusterFirst
   extraEnv: []
   cmdlineParams: {}
+  basePath: /
   replicaCount: 1
   autoscaling:
     enabled: false
@@ -462,6 +463,7 @@ collector:
 
 query:
   enabled: true
+  basePath: /
   oAuthSidecar:
     enabled: false
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0


### PR DESCRIPTION
#### What this PR does

 - fixes query.ingress for nginx-ingress-controller (probably more ingress controllers)
 - used in here https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/templates/query-ing.yaml#L4 and here https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/templates/query-ing.yaml#L28 but not defined :)
 - if it's not defined, chart will produce paths like this:
 
```yaml
- pathType: ImplementationSpecific
  backend:
    service:
      name: jaeger-query
      port:
        number: 80
```
- missing the `path: /`, I'm not sure if it's problem only for `nginx-ingress-controller` or for more controllers

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
