### PR TITLE
[jaeger] Remove storage.cmdArgs from es index cleaner commandline args

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.65.3
+version: 0.65.4
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -54,7 +54,6 @@ spec:
               - {{ .Values.esIndexCleaner.numberOfDays | quote }}
               - {{ include "elasticsearch.client.url" . }}
               {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.esIndexCleaner.cmdlineParams ) | nindent 14  }}
-              {{- include "storage.cmdArgs" . | nindent 14 }}
             env:
             {{- if .Values.esIndexCleaner.extraEnv }}
               {{- toYaml .Values.esIndexCleaner.extraEnv | nindent 14 }}


### PR DESCRIPTION
#### What this PR does

This PR removes the cmdline arguments of the storage from the es-index-cleaner arguments

#### Which issue this PR fixes

- fixes #424

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
