### PR TITLE
[jaeger] Provide the ability to connect to Elasticsearch with TLS

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.5
+version: 0.67.6
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -353,6 +353,7 @@ Elasticsearch related environment variables
 {{- if not .Values.storage.elasticsearch.anonymous }}
 - name: ES_USERNAME
   value: {{ .Values.storage.elasticsearch.user }}
+{{- end }}
 {{- if .Values.storage.elasticsearch.usePassword }}
 - name: ES_PASSWORD
   valueFrom:
@@ -360,6 +361,11 @@ Elasticsearch related environment variables
       name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
       key: {{ default "password" .Values.storage.elasticsearch.existingSecretKey }}
 {{- end }}
+{{- if .Values.storage.elasticsearch.tls.enabled }}
+- name: ES_TLS_ENABLED
+  value: "true"
+- name: ES_TLS_CA
+  value: /es-tls/ca-cert.pem
 {{- end }}
 {{- if .Values.storage.elasticsearch.indexPrefix }}
 - name: ES_INDEX_PREFIX

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -158,6 +158,12 @@ spec:
             subPath: "client-key.pem"
             readOnly: true
         {{- end }}
+        {{- if .Values.storage.elasticsearch.tls.enabled }}
+          - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+            mountPath: "/es-tls/ca-cert.pem"
+            subPath: "ca-cert.pem"
+            readOnly: true
+        {{- end }}
         {{- if .Values.collector.samplingConfig}}
           - name: strategies
             mountPath: /etc/conf/
@@ -185,6 +191,11 @@ spec:
           secret:
             secretName: {{ .Values.storage.cassandra.tls.secretName }}
       {{- end }}
+      {{- if .Values.storage.elasticsearch.tls.enabled }}
+        - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+          secret:
+            secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+       {{- end }}
     {{- with .Values.collector.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -74,6 +74,12 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.storage.elasticsearch.tls.enabled }}
+              - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+                mountPath: "/es-tls/ca-cert.pem"
+                subPath: "ca-cert.pem"
+                readOnly: true
+            {{- end }}
           restartPolicy: OnFailure
         {{- with .Values.esIndexCleaner.nodeSelector }}
           nodeSelector:
@@ -97,5 +103,10 @@ spec:
             - name: {{ .name }}
               secret:
                 secretName: {{ .secretName }}
+        {{- end }}
+        {{- if .Values.storage.elasticsearch.tls.enabled }}
+            - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+              secret:
+                secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -88,6 +88,12 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.storage.elasticsearch.tls.enabled }}
+              - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+                mountPath: "/es-tls/ca-cert.pem"
+                subPath: "ca-cert.pem"
+                readOnly: true
+            {{- end }}
           volumes:
           {{- range .Values.esLookback.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -98,5 +104,10 @@ spec:
             - name: {{ .name }}
               secret:
                 secretName: {{ .secretName }}
+        {{- end }}
+        {{- if .Values.storage.elasticsearch.tls.enabled }}
+            - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+              secret:
+                secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -88,6 +88,12 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+            {{- if .Values.storage.elasticsearch.tls.enabled }}
+              - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+                mountPath: "/es-tls/ca-cert.pem"
+                subPath: "ca-cert.pem"
+                readOnly: true
+            {{- end }}
           volumes:
           {{- range .Values.esRollover.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -98,5 +104,10 @@ spec:
             - name: {{ .name }}
               secret:
                 secretName: {{ .secretName }}
+        {{- end }}
+        {{- if .Values.storage.elasticsearch.tls.enabled }}
+            - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+              secret:
+                secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -109,6 +109,12 @@ spec:
             subPath: "client-key.pem"
             readOnly: true
         {{- end }}
+        {{- if .Values.storage.elasticsearch.tls.enabled }}
+          - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+            mountPath: "/es-tls/ca-cert.pem"
+            subPath: "ca-cert.pem"
+            readOnly: true
+        {{- end }}
         {{- if .Values.query.config}}
           - name: ui-configuration
             mountPath: /etc/conf/
@@ -235,6 +241,11 @@ spec:
           secret:
             secretName: {{ .Values.storage.cassandra.tls.secretName }}
       {{- end }}
+      {{- if .Values.storage.elasticsearch.tls.enabled }}
+        - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+          secret:
+            secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+       {{- end }}
 {{- if .Values.query.oAuthSidecar.enabled }}
       {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}
         - name: {{ .name }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -114,6 +114,9 @@ storage:
       # es.server-urls: http://elasticsearch-master:9200
       # es.username: elastic
       # es.index-prefix: test
+    tls:
+      enabled: false
+      secretName: es-tls-secret
   kafka:
     brokers:
       - kafka:9092


### PR DESCRIPTION
Signed-off-by: Guillaume DOUSSIN <guillaume.doussin@amadeus.com>

#### What this PR does
Provide the ability to connect to an elastic search cluster using TLS.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
