### PR TITLE
[jaeger] - allinone use tpl function for args

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.64.2
+version: 0.64.3
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.37.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.64.3
+version: 0.65.5
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -50,7 +50,7 @@ spec:
           name: jaeger
           args:
             {{- range $arg := .Values.allInOne.args }}
-            - "{{ $arg }}"
+            - "{{ tpl $arg $ }}"
             {{- end }}
           ports:
             - containerPort: 5775


### PR DESCRIPTION
Signed-off-by: Pierre Tessier <pierre@pierretessier.com>

#### What this PR does

Uses the Helm [tpl](https://helm.sh/docs/howto/charts_tips_and_tricks/#using-the-tpl-function) function to allow for command line args to be templated. This is required when Jaeger is used as a chart dependency and some options can only be determined at helm templating time (ie: release name).

#### Which issue this PR fixes

This allows for the OpenTelemetry demo to leverage Jaeger for tracing with Prometheus-backed metrics store configured in the Jaeger AllInOne deploy as merged recently in the otel demo [PR 655](https://github.com/open-telemetry/opentelemetry-demo/pull/655) 

The OpenTelemetry demo helm chart will have a section to configure the prometheus sever url that looks like this:

```yaml
  allInOne:
    enabled: true
    args:
      - "--prometheus.server-url"
      - 'http://{{ include "otel-demo.name" . }}-prometheus-server:9090'
    extraEnv:
      - name: METRICS_STORAGE_TYPE
        value: prometheus
```

Passing in the `{{ include "otel-demo.name" .}}` portion for the command line argument is what this PR enables.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
