### PR TITLE
[jaeger-operator] Adding serviceExtraLable for service

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.38.0
+version: 2.39.0
 appVersion: 1.39.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -55,6 +55,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 
 | Parameter               | Description                                                                                                 | Default                         |
 | :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
+| `serviceExtraLabels`    | Additional labels to jaeger-operator service  | `{}`
 | `extraLabels`           | Additional labels to jaeger-operator deployment  | `{}`
 | `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
 | `image.tag`             | Controller container image tag                                                                              | `1.39.0`                        |

--- a/charts/jaeger-operator/templates/service.yaml
+++ b/charts/jaeger-operator/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
 {{ include "jaeger-operator.labels" . | indent 4 }}
+{{- with .Values.serviceExtraLabels }}
+{{ . | toYaml | indent 4 }}
+{{- end }}
 {{- if .Values.service.annotations }}
   annotations:
 {{ toYaml .Values.service.annotations | indent 4 }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -63,6 +63,10 @@ extraEnv: []
   # - name: LOG-LEVEL
   #   value: debug
 
+serviceExtraLabels: {}
+  # Specifies extra labels for the operator-metric service:
+  # foo: bar
+
 extraLabels: {}
   # Specifies extra labels for the operator deployment:
   # foo: bar


### PR DESCRIPTION
#### What this PR does
This PR adds a value called 'serviceExtraLabels' to make it possible to add a label to the service you may not want to have in the operator to for example create a 'serviceMonitor' for it.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
