### PR TITLE
[jaeger] Remove storage.cmdArgs from es index rollover commandline args

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.66.0
+version: 0.66.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -68,7 +68,6 @@ spec:
               - lookback
               - {{ include "elasticsearch.client.url" . }}
               {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.esLookback.cmdlineParams ) | nindent 14  }}
-              {{- include "storage.cmdArgs" . | nindent 14 }}
             env:
               {{ include "elasticsearch.env" . | nindent 14 }}
               {{- if .Values.esLookback.extraEnv }}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -68,7 +68,6 @@ spec:
               - rollover
               - {{ include "elasticsearch.client.url" . }}
               {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.esRollover.cmdlineParams ) | nindent 14  }}
-              {{- include "storage.cmdArgs" . | nindent 14 }}
             env:
               {{ include "elasticsearch.env" . | nindent 14 }}
               {{- if .Values.esRollover.extraEnv }}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -57,7 +57,6 @@ spec:
             - init
             - {{ include "elasticsearch.client.url" . }}
             {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.esRollover.cmdlineParams ) | nindent 12  }}
-            {{- include "storage.cmdArgs" . | nindent 12 }}
           env:
             {{ include "elasticsearch.env" . | nindent 12 }}
             {{- with .Values.esRollover.initHook.extraEnv }}


### PR DESCRIPTION

#### What this PR does

Storage cmdline args like `es.num-replicas` don't work for es rollover, including them makes it impossible to deploy (crashloop unknown cmdline arguments).

#### Which issue this PR fixes

- fixes #427

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
