### PR TITLE
jaeger: upgrade Kafka chart dependency from 18.x to 19.x

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.65.5
+version: 0.66.0
 keywords:
   - jaeger
   - opentracing
@@ -34,7 +34,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^18.0.8
+    version: ^19.1.5
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common


### PR DESCRIPTION
Signed-off-by: Greg Burton <9094087+gburton1@users.noreply.github.com>

#### What this PR does
The jump from from 18.x to 19.x Kafka chart is pretty minor. The underlying Kafka version jumps from 3.2 to 3.3. This is the second PR to do this change, as the first one was accidentally reverted by someone else's PR.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ x] Chart Version bumped
- [x ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ x] README.md has been updated to match version/contain new values
