### PR TITLE
[jaeger] Will allow anonymous login to ElasticSearch

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.0
+version: 0.67.1
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -350,6 +350,7 @@ Elasticsearch related environment variables
 {{- define "elasticsearch.env" -}}
 - name: ES_SERVER_URLS
   value: {{ include "elasticsearch.client.url" . }}
+{{- if not .Values.storage.elasticsearch.anonymous }}
 - name: ES_USERNAME
   value: {{ .Values.storage.elasticsearch.user }}
 {{- if .Values.storage.elasticsearch.usePassword }}
@@ -358,6 +359,7 @@ Elasticsearch related environment variables
     secretKeyRef:
       name: {{ if .Values.storage.elasticsearch.existingSecret }}{{ .Values.storage.elasticsearch.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-elasticsearch{{- end }}
       key: {{ default "password" .Values.storage.elasticsearch.existingSecretKey }}
+{{- end }}
 {{- end }}
 {{- if .Values.storage.elasticsearch.indexPrefix }}
 - name: ES_INDEX_PREFIX

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -92,6 +92,7 @@ storage:
     scheme: http
     host: elasticsearch-master
     port: 9200
+    anonymous: false
     user: elastic
     usePassword: true
     password: changeme


### PR DESCRIPTION
Signed-off-by: Piotr Klubinski <pklubinski@gmail.com>

#### What this PR does

This PR allows to not render ES_USERNAME or ES_PASSWORD if `storage.elasticsearch.anonymous: true`.

#### Which issue this PR fixes

- fixes #441

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
