### PR TITLE
[jaeger] Make pullPolicy consistently IfNotPresent

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.1
+version: 0.67.2
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -601,7 +601,7 @@ spark:
   image: jaegertracing/spark-dependencies
   imagePullSecrets: []
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   cmdlineParams: {}
   extraEnv: []
   schedule: "49 23 * * *"
@@ -640,7 +640,7 @@ esIndexCleaner:
   annotations: {}
   image: jaegertracing/jaeger-es-index-cleaner
   imagePullSecrets: []
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   cmdlineParams: {}
   extraEnv: []
     # - name: ROLLOVER
@@ -682,7 +682,7 @@ esRollover:
   image: jaegertracing/jaeger-es-rollover
   imagePullSecrets: []
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   cmdlineParams: {}
   extraEnv:
     - name: CONDITIONS
@@ -731,7 +731,7 @@ esLookback:
   image: jaegertracing/jaeger-es-rollover
   imagePullSecrets: []
   tag: latest
-  pullPolicy: Always
+  pullPolicy: IfNotPresent
   cmdlineParams: {}
   extraEnv:
     - name: UNIT
@@ -773,7 +773,7 @@ hotrod:
   replicaCount: 1
   image:
     repository: jaegertracing/example-hotrod
-    pullPolicy: Always
+    pullPolicy: IfNotPresent
     pullSecrets: []
   service:
     annotations: {}


### PR DESCRIPTION
Most images are set to a pullPolicy of IfNotPresent, but the following images were set to Always prior to this commit:

  - spark
  - esIndexCleaner
  - esRollover
  - esLookback
  - hotrod

This makes it confusing when testing local images in a minikube cluster. Instead be consistent and use IfNotPresent for all images, which makes local testing easier.

Signed-off-by: Jesse Hathaway <jhathaway@wikimedia.org>

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
