### PR TITLE
[jaeger-operator] Allow setting the Certificate Issuer Kind

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.39.0
+version: 2.40.0
 appVersion: 1.39.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/certificate.yaml
+++ b/charts/jaeger-operator/templates/certificate.yaml
@@ -9,7 +9,11 @@ spec:
   - "{{ default "jaeger-operator-webhook-service" .Values.webhooks.service.name }}.{{ .Release.Namespace }}.svc"
   - "{{ default "jaeger-operator-webhook-service" .Values.webhooks.service.name }}.{{ .Release.Namespace }}.svc.cluster.local"
   issuerRef:
+    {{- if .Values.certs.issuer.create }}
     kind: Issuer
+    {{- else }}
+    kind: {{ .Values.certs.certificate.issuerKind }}
+    {{- end }}
     name: {{ default "selfsigned-issuer" .Values.certs.issuer.name }}
   secretName: {{ default "jaeger-operator-service-cert" .Values.certs.certificate.secretName }}
   subject:

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -16,6 +16,10 @@ certs:
     create: true
     namespace: ""
     secretName: ""
+    # Specify the cert-manager issuer kind to use an existing cert-manager
+    # issuer; typically Issuer or ClusterIssuer
+    # This field will be ignored if issuer.create is true
+    issuerKind: Issuer
 
 webhooks:
   mutatingWebhook:


### PR DESCRIPTION
#### What this PR does

Allow setting the `Certificate` `Issuer` kind to `ClusterIssuer` while retaining the default type of `Issuer`.

If `certs.issuer.create=true` is set, the Certificate's Issuer Kind will always be `Issuer`, since this change does not allow the built-in issuer's kind to be modified.

#### Which issue this PR fixes

- fixes #386

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] ~~README.md has been updated to match version/contain new values~~
