### PR TITLE
[jaeger] Add kubeVersion to indicate Kubernetes compatibility

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,9 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.2
+version: 0.67.3
+# CronJobs require v1.21
+kubeVersion: '>= 1.21'
 keywords:
   - jaeger
   - opentracing


### PR DESCRIPTION
Prior to this commit helm could determine, prior to an apply, whether the chart is compatible with the local Kubernetes cluster.

After this commit helm is able to reject the apply immediately.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
