### PR TITLE
[jaeger] Allow pre-release format in helm-chart requirements

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,9 +3,9 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.3
+version: 0.67.4
 # CronJobs require v1.21
-kubeVersion: '>= 1.21'
+kubeVersion: '>= 1.21-0'
 keywords:
   - jaeger
   - opentracing


### PR DESCRIPTION
#### What this PR does

Some Kubernetes vendors use a pre-release format for versioning, AWS EKS example: v1.24.8-eks-ffeb93d
Current requirements are strict only with a release version 
as result >= 1.21 don't tolerate with v1.24.8-eks-ffeb93d
Allow pre-release format with appendix -0 in the requirements for the chart.
[more info about working with pre-release format](https://github.com/Masterminds/semver#working-with-prerelease-versions)


#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
