### PR TITLE
[jaeger] #452 support initContainers

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.67.6
+version: 0.68.0
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -42,6 +42,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.collector.initContainers }}
       initContainers:
         {{- toYaml .Values.collector.initContainers | nindent 8 }}
       {{- end}}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -42,6 +42,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      initContainers:
+        {{- toYaml .Values.collector.initContainers | nindent 8 }}
+      {{- end}}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
         securityContext:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -466,6 +466,7 @@ collector:
     # -- ServiceMonitor metric relabel configs to apply to samples before ingestion
     # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
     metricRelabelings: []
+  initContainers: []
 
 query:
   enabled: true


### PR DESCRIPTION
#### What this PR does

Support InitContainers in collector deployment

#### Which issue this PR fixes

- fixes #452

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values (_Should I write something?_)
