### PR TITLE
[jaeger] Add flag enabling the ability to disable the cassandra-schema Job

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.68.0
+version: 0.68.1
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -1,5 +1,6 @@
 {{- if .Values.collector.enabled -}}
 {{- if eq .Values.storage.type "cassandra" -}}
+{{- if .Values.storage.cassandra.schemaJobEnabled -}}
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -98,5 +99,6 @@ spec:
           secret:
             secretName: {{ .Values.storage.cassandra.tls.secretName }}
       {{- end }}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -63,6 +63,7 @@ storage:
   cassandra:
     host: cassandra
     port: 9042
+    schemaJobEnabled: true
     tls:
       enabled: false
       secretName: cassandra-tls-secret

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -63,6 +63,8 @@ storage:
   cassandra:
     host: cassandra
     port: 9042
+    # Change this value to false if you want to avoid starting the
+    # -cassandra-schema Job
     schemaJobEnabled: true
     tls:
       enabled: false


### PR DESCRIPTION
By default, the behavior will be identical to what it was before.  Enabled by default.

This flag though, when set to false will disable the creation of the cassandra-schema-job Job resource.

#### What this PR does

I have a use case where I don't want the helm chart to attempt to run the cassandra-schema-job at all.  Schema creation is our cassandra db is handled another way.  Also I think I'm having trouble with this job running cleanly against our ScyllaDB / cassandra environment.  So in the interest of having cleaner k8s deployments, wanted to just have the option to be able to turn this off.

This PR adds a flag in values. `storage.cassandra.schemaJobEnabled` which defaults to `true` so that existing behavior doesn't change at all.   If you change the value of `storage.cassandra.schemaJobEnabled=false` Then the `FULLNAME-cassandra-schema` Job will not be created.

#### Which issue this PR fixes

None

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
