### PR TITLE
[jaeger] feat: specify ingress pathType as variable ✨

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.39.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.68.1
+version: 0.68.2
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/allinone-ing.yaml
+++ b/charts/jaeger/templates/allinone-ing.yaml
@@ -21,7 +21,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: {{ default "Prefix" $.Values.allInOne.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" $.Values.allInOne.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16686 "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.allInOne.ingress.tls }}

--- a/charts/jaeger/templates/allinone-ing.yaml
+++ b/charts/jaeger/templates/allinone-ing.yaml
@@ -21,9 +21,7 @@ spec:
       http:
         paths:
           - path: /
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: {{ default "Prefix" $.Values.allInOne.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16686 "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.allInOne.ingress.tls }}

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -26,7 +26,7 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            pathType: {{ default "Prefix" $.Values.collector.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" $.Values.collector.ingress.pathType }}
             {{- $servicePortString := (include "jaeger.collector.ingressServicePort" (dict "defaultServicePort" $defaultServicePort "context" .)) }}
             {{- $servicePort := default $servicePortString ($servicePortString | float64) }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.collector.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -26,9 +26,7 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: {{ default "Prefix" $.Values.collector.ingress.pathType }}
             {{- $servicePortString := (include "jaeger.collector.ingressServicePort" (dict "defaultServicePort" $defaultServicePort "context" .)) }}
             {{- $servicePort := default $servicePortString ($servicePortString | float64) }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.collector.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -24,9 +24,7 @@ spec:
       http:
         paths:
           - path: /
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: {{ default "Prefix" $.Values.hotrod.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-hotrod" $serviceName) "servicePort" $servicePort "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.hotrod.ingress.tls }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -24,7 +24,7 @@ spec:
       http:
         paths:
           - path: /
-            pathType: {{ default "Prefix" $.Values.hotrod.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" $.Values.hotrod.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (printf "%s-hotrod" $serviceName) "servicePort" $servicePort "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.hotrod.ingress.tls }}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -26,12 +26,12 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            pathType: {{ default "Prefix" $.Values.query.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" $.Values.query.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
           {{- end -}}
           {{- if .Values.query.ingress.health.exposed }}
           - path: /health
-            pathType: {{ default "Prefix" $.Values.query.ingress.pathType }}
+            pathType: {{ default "ImplementationSpecific" $.Values.query.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16687 "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.query.ingress.tls }}

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -26,16 +26,12 @@ spec:
       http:
         paths:
           - path: {{ $basePath }}
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: {{ default "Prefix" $.Values.query.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" $servicePort "context" $) | nindent 14 }}
           {{- end -}}
           {{- if .Values.query.ingress.health.exposed }}
           - path: /health
-            {{- if eq "true" (include "common.ingress.supportsPathType" $) }}
-            pathType: ImplementationSpecific
-            {{- end }}
+            pathType: {{ default "Prefix" $.Values.query.ingress.pathType }}
             backend: {{- include "common.ingress.backend" (dict "serviceName" (include "jaeger.query.name" $) "servicePort" 16687 "context" $) | nindent 14 }}
   {{- end -}}
   {{- if .Values.query.ingress.tls }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -48,7 +48,7 @@ allInOne:
     #   - secretName: chart-example-tls
     #     hosts:
     #       - chart-example.local
-    pathType: ImplementationSpecific
+    pathType:
   # resources:
   #   limits:
   #     cpu: 500m
@@ -398,7 +398,7 @@ collector:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
-    pathType: ImplementationSpecific
+    pathType:
   resources: {}
     # limits:
     #   cpu: 1
@@ -547,7 +547,7 @@ query:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
-    pathType: ImplementationSpecific
+    pathType:
     health:
       exposed: false
   resources: {}
@@ -808,7 +808,7 @@ hotrod:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
-    pathType: ImplementationSpecific
+    pathType:
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -48,6 +48,7 @@ allInOne:
     #   - secretName: chart-example-tls
     #     hosts:
     #       - chart-example.local
+    pathType: ImplementationSpecific
   # resources:
   #   limits:
   #     cpu: 500m
@@ -397,6 +398,7 @@ collector:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+    pathType: ImplementationSpecific
   resources: {}
     # limits:
     #   cpu: 1
@@ -545,6 +547,7 @@ query:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+    pathType: ImplementationSpecific
     health:
       exposed: false
   resources: {}
@@ -805,6 +808,7 @@ hotrod:
       # - secretName: chart-example-tls
       #   hosts:
       #     - chart-example.local
+    pathType: ImplementationSpecific
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
#### What this PR does

It adds the option for the user to specify the ingress `pathType` because the current implementation is very inflexible.

#### Which issue this PR fixes

- fixes #423
- fixes #435

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
