### PR TITLE
[jaeger] Network policy support, query & collector

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.42.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.69.0
+version: 0.69.1
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -453,3 +453,73 @@ Usage:
 {{- end }}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Provides a basic ingress network policy
+*/}}
+{{- define "jaeger.ingress.networkPolicy" -}}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-ingress" .Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ .Component }}
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Component }}
+  policyTypes:
+  - Ingress
+  ingress:
+  {{- if or .ComponentValues.networkPolicy.ingressRules.namespaceSelector .ComponentValues.networkPolicy.ingressRules.podSelector }}
+  - from:
+    {{- if .ComponentValues.networkPolicy.ingressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .ComponentValues.networkPolicy.ingressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.ingressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .ComponentValues.networkPolicy.ingressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.ingressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end -}}
+
+{{/*
+Provides a basic egress network policy
+*/}}
+{{- define "jaeger.egress.networkPolicy" -}}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" .Name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: {{ .Component }}
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: {{ .Component }}
+  policyTypes:
+  - Egress
+  egress:
+  {{- if or .ComponentValues.networkPolicy.egressRules.namespaceSelector .ComponentValues.networkPolicy.egressRules.podSelector }}
+  - to:
+    {{- if .ComponentValues.networkPolicy.egressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.egressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .ComponentValues.networkPolicy.egressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.egressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .ComponentValues.networkPolicy.egressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end -}}

--- a/charts/jaeger/templates/collector-networkpolicy-egress.yaml
+++ b/charts/jaeger/templates/collector-networkpolicy-egress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.networkPolicy.enabled .Values.collector.networkPolicy.enabled .Values.collector.networkPolicy.egressRules }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" (include "jaeger.collector.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: collector
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: collector
+  policyTypes:
+  - Egress
+  egress:
+  {{- if or .Values.collector.networkPolicy.egressRules.namespaceSelector .Values.collector.networkPolicy.egressRules.podSelector }}
+  - to:
+    {{- if .Values.collector.networkPolicy.egressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .Values.collector.networkPolicy.egressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.collector.networkPolicy.egressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/jaeger/templates/collector-networkpolicy-egress.yaml
+++ b/charts/jaeger/templates/collector-networkpolicy-egress.yaml
@@ -1,31 +1,5 @@
 {{- if and .Values.networkPolicy.enabled .Values.collector.networkPolicy.enabled .Values.collector.networkPolicy.egressRules }}
-apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
-kind: NetworkPolicy
-metadata:
-  name: {{ printf "%s-egress" (include "jaeger.collector.name" .) }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: collector
-    {{- include "jaeger.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: collector
-  policyTypes:
-  - Egress
-  egress:
-  {{- if or .Values.collector.networkPolicy.egressRules.namespaceSelector .Values.collector.networkPolicy.egressRules.podSelector }}
-  - to:
-    {{- if .Values.collector.networkPolicy.egressRules.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.namespaceSelector "context" $) | nindent 10 }}
-    {{- end }}
-    {{- if .Values.collector.networkPolicy.egressRules.podSelector }}
-    - podSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.podSelector "context" $) | nindent 10 }}
-    {{- end }}
-  {{- end }}
-  {{- if .Values.collector.networkPolicy.egressRules.customRules }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
-  {{- end }}
+{{- $extraVals := dict "Name" (include "jaeger.collector.name" .) "Component" "collector" "ComponentValues" .Values.collector -}}
+{{- $npVals := merge $extraVals . -}}
+{{ include "jaeger.egress.networkPolicy" $npVals }}
 {{- end }}

--- a/charts/jaeger/templates/collector-networkpolicy-ingress.yaml
+++ b/charts/jaeger/templates/collector-networkpolicy-ingress.yaml
@@ -1,31 +1,5 @@
-{{- if and .Values.networkPolicy.enabled .Values.collector.networkPolicy.enabled .Values.collector.networkPolicy.ingressRules }}
-apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
-kind: NetworkPolicy
-metadata:
-  name: {{ printf "%s-ingress" (include "jaeger.collector.name" .) }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: collector
-    {{- include "jaeger.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: collector
-  policyTypes:
-    - Ingress
-  ingress:
-  {{- if or .Values.collector.networkPolicy.ingressRules.namespaceSelector .Values.collector.networkPolicy.ingressRules.podSelector }}
-  - from:
-    {{- if .Values.collector.networkPolicy.ingressRules.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 10 }}
-    {{- end }}
-    {{- if .Values.collector.networkPolicy.ingressRules.podSelector }}
-    - podSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.podSelector "context" $) | nindent 10 }}
-    {{- end }}
-  {{- end }}
-  {{- if .Values.collector.networkPolicy.ingressRules.customRules }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.customRules "context" $) | nindent 2 }}
-  {{- end }}
-{{- end }}
+{{- if and .Values.networkPolicy.enabled .Values.collector.networkPolicy.enabled .Values.collector.networkPolicy.ingressRules -}}
+{{- $extraVals := dict "Name" (include "jaeger.collector.name" .) "Component" "collector" "ComponentValues" .Values.collector -}}
+{{- $npVals := merge $extraVals . -}}
+{{ include "jaeger.ingress.networkPolicy" $npVals }}
+{{- end -}}

--- a/charts/jaeger/templates/collector-networkpolicy-ingress.yaml
+++ b/charts/jaeger/templates/collector-networkpolicy-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.networkPolicy.enabled .Values.collector.networkPolicy.enabled .Values.collector.networkPolicy.ingressRules }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-ingress" (include "jaeger.collector.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: collector
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: collector
+  policyTypes:
+    - Ingress
+  ingress:
+  {{- if or .Values.collector.networkPolicy.ingressRules.namespaceSelector .Values.collector.networkPolicy.ingressRules.podSelector }}
+  - from:
+    {{- if .Values.collector.networkPolicy.ingressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .Values.collector.networkPolicy.ingressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.collector.networkPolicy.ingressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.collector.networkPolicy.ingressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/jaeger/templates/query-networkpolicy-egress.yaml
+++ b/charts/jaeger/templates/query-networkpolicy-egress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.networkPolicy.enabled .Values.query.networkPolicy.enabled .Values.query.networkPolicy.egressRules }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-egress" (include "jaeger.query.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: query
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query
+  policyTypes:
+  - Egress
+  egress:
+  {{- if or .Values.query.networkPolicy.egressRules.namespaceSelector .Values.query.networkPolicy.egressRules.podSelector }}
+  - to:
+    {{- if .Values.query.networkPolicy.egressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .Values.query.networkPolicy.egressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.query.networkPolicy.egressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/jaeger/templates/query-networkpolicy-egress.yaml
+++ b/charts/jaeger/templates/query-networkpolicy-egress.yaml
@@ -1,31 +1,5 @@
 {{- if and .Values.networkPolicy.enabled .Values.query.networkPolicy.enabled .Values.query.networkPolicy.egressRules }}
-apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
-kind: NetworkPolicy
-metadata:
-  name: {{ printf "%s-egress" (include "jaeger.query.name" .) }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: query
-    {{- include "jaeger.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: query
-  policyTypes:
-  - Egress
-  egress:
-  {{- if or .Values.query.networkPolicy.egressRules.namespaceSelector .Values.query.networkPolicy.egressRules.podSelector }}
-  - to:
-    {{- if .Values.query.networkPolicy.egressRules.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.namespaceSelector "context" $) | nindent 10 }}
-    {{- end }}
-    {{- if .Values.query.networkPolicy.egressRules.podSelector }}
-    - podSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.podSelector "context" $) | nindent 10 }}
-    {{- end }}
-  {{- end }}
-  {{- if .Values.query.networkPolicy.egressRules.customRules }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
-  {{- end }}
+{{- $extraVals := dict "Name" (include "jaeger.query.name" .) "Component" "query" "ComponentValues" .Values.query -}}
+{{- $npVals := merge $extraVals . -}}
+{{ include "jaeger.egress.networkPolicy" $npVals }}
 {{- end }}

--- a/charts/jaeger/templates/query-networkpolicy-ingress.yaml
+++ b/charts/jaeger/templates/query-networkpolicy-ingress.yaml
@@ -1,31 +1,5 @@
 {{- if and .Values.networkPolicy.enabled .Values.query.networkPolicy.enabled .Values.query.networkPolicy.ingressRules }}
-apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
-kind: NetworkPolicy
-metadata:
-  name: {{ printf "%s-ingress" (include "jaeger.query.name" .) }}
-  namespace: {{ .Release.Namespace }}
-  labels:
-    app.kubernetes.io/component: query
-    {{- include "jaeger.labels" . | nindent 4 }}
-spec:
-  podSelector:
-    matchLabels:
-      app.kubernetes.io/component: query
-  policyTypes:
-    - Ingress
-  ingress:
-  {{- if or .Values.query.networkPolicy.ingressRules.namespaceSelector .Values.query.networkPolicy.ingressRules.podSelector }}
-  - from:
-    {{- if .Values.query.networkPolicy.ingressRules.namespaceSelector }}
-    - namespaceSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 10 }}
-    {{- end }}
-    {{- if .Values.query.networkPolicy.ingressRules.podSelector }}
-    - podSelector:
-        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.podSelector "context" $) | nindent 10 }}
-    {{- end }}
-  {{- end }}
-  {{- if .Values.query.networkPolicy.ingressRules.customRules }}
-  {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.customRules "context" $) | nindent 2 }}
-  {{- end }}
+{{- $extraVals := dict "Name" (include "jaeger.query.name" .) "Component" "query" "ComponentValues" .Values.query -}}
+{{- $npVals := merge $extraVals . -}}
+{{ include "jaeger.ingress.networkPolicy" $npVals }}
 {{- end }}

--- a/charts/jaeger/templates/query-networkpolicy-ingress.yaml
+++ b/charts/jaeger/templates/query-networkpolicy-ingress.yaml
@@ -1,0 +1,31 @@
+{{- if and .Values.networkPolicy.enabled .Values.query.networkPolicy.enabled .Values.query.networkPolicy.ingressRules }}
+apiVersion: {{ include "common.capabilities.networkPolicy.apiVersion" . }}
+kind: NetworkPolicy
+metadata:
+  name: {{ printf "%s-ingress" (include "jaeger.query.name" .) }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/component: query
+    {{- include "jaeger.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      app.kubernetes.io/component: query
+  policyTypes:
+    - Ingress
+  ingress:
+  {{- if or .Values.query.networkPolicy.ingressRules.namespaceSelector .Values.query.networkPolicy.ingressRules.podSelector }}
+  - from:
+    {{- if .Values.query.networkPolicy.ingressRules.namespaceSelector }}
+    - namespaceSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.namespaceSelector "context" $) | nindent 10 }}
+    {{- end }}
+    {{- if .Values.query.networkPolicy.ingressRules.podSelector }}
+    - podSelector:
+        matchLabels: {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.podSelector "context" $) | nindent 10 }}
+    {{- end }}
+  {{- end }}
+  {{- if .Values.query.networkPolicy.ingressRules.customRules }}
+  {{- include "common.tplvalues.render" (dict "value" .Values.query.networkPolicy.ingressRules.customRules "context" $) | nindent 2 }}
+  {{- end }}
+{{- end }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -7,6 +7,9 @@ provisionDataStore:
   elasticsearch: false
   kafka: false
 
+networkPolicy:
+  enabled: false
+
 # Overrides the image tag where default is the chart appVersion.
 tag: ""
 
@@ -472,6 +475,16 @@ collector:
     # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#endpoint
     metricRelabelings: []
   initContainers: []
+  networkPolicy:
+    enabled: false
+    # ingressRules:
+    #   namespaceSelector: {}
+    #   podSelector: {}
+    #   customRules: []
+    # egressRules:
+    #   namespaceSelector: {}
+    #   podSelector: {}
+    #   customRules: []
 
 query:
   enabled: true
@@ -604,6 +617,16 @@ query:
   #       "trackErrors": true
   #     }
   #   }
+  networkPolicy:
+    enabled: false
+    # ingressRules:
+    #   namespaceSelector: {}
+    #   podSelector: {}
+    #   customRules: []
+    # egressRules:
+    #   namespaceSelector: {}
+    #   podSelector: {}
+    #   customRules: []
 
 spark:
   enabled: false


### PR DESCRIPTION
Adds network policy support to the query and collector components.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
