### PR TITLE
[jaeger] add extraArgs and extraEnv to hotrod

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.42.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.69.1
+version: 0.70.0
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -398,3 +398,31 @@ extraObjects:
       - kind: ServiceAccount
         name: "{{ include \"jaeger.esLookback.serviceAccountName\" . }}"
 ```
+
+## Configuring the hotrod example application to send traces to the OpenTelemetry collector
+
+If the `hotrod` example application is enabled it will export traces to Jaeger
+via the Jaeger exporter. To switch this to another collector and/or protocol,
+such as an OpenTelemetry OTLP Collector, see the example below.
+
+The primary use case of sending the traces to the collector instead of directly
+to Jaeger is to verify traces can get back to Jaeger or another distributed
+tracing store and verify that pipeline with the pre-instrumented hotrod
+application.
+
+**NOTE: This will not install or setup the OpenTelemetry collector. To setup an example OpenTelemetry Collector, see the [OpenTelemetry helm
+charts](https://github.com/open-telemetry/opentelemetry-helm-charts/tree/main/charts/opentelemetry-collector).**
+
+Content of the `jaeger-values.yaml` file:
+
+```YAML
+hotrod:
+  enabled: true
+  # Switch from the jaeger protocol to OTLP
+  extraArgs:
+    - --otel-exporter=otlp
+  # Set the address of the OpenTelemetry collector endpoint
+  extraEnv:
+    - name: OTEL_EXPORTER_OTLP_ENDPOINT
+      value: http://my-otel-collector-opentelemetry-collector:4318
+```

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -31,11 +31,19 @@ spec:
             {{- toYaml .Values.hotrod.securityContext | nindent 12 }}
           image: {{ .Values.hotrod.image.repository }}:{{- include "jaeger.image.tag" . }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
+          args:
+            {{- toYaml .Values.hotrod.args | nindent 12 }}
+          {{- with .Values.hotrod.extraArgs }}
+            {{- toYaml . | nindent 12 }}
+          {{-  end }}
           env:
             - name: JAEGER_AGENT_HOST
               value: {{ template "jaeger.hotrod.tracing.host" . }}
             - name: JAEGER_AGENT_PORT
               value: {{ .Values.hotrod.tracing.port | quote }}
+          {{- if .Values.hotrod.extraEnv }}
+            {{- toYaml .Values.hotrod.extraEnv | nindent 12 }}
+          {{- end }}
           ports:
             - name: http
               containerPort: 8080

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -804,6 +804,17 @@ hotrod:
   podSecurityContext: {}
   securityContext: {}
   replicaCount: 1
+  # set the primary command(s) for the hotrod application
+  args:
+    - all
+  # add extra arguments to the hotrod application to customize tracing
+  extraArgs: []
+  #   - --otel-exporter=otlp
+  #   - --jaeger-ui=http://jaeger.chart.local
+  # add extra environment variables to the hotrod application
+  extraEnv: []
+  #   - name: OTEL_EXPORTER_OTLP_ENDPOINT
+  #     value: http://my-otel-collector.chart.local:4318
   image:
     repository: jaegertracing/example-hotrod
     pullPolicy: IfNotPresent


### PR DESCRIPTION


#### What this PR does

* Default the `args` in the container to "all". This is the current default in the container.
* Allow extra arguments to be added to the `hotrod` container
* Allow environment variables to be added to the `hotrod` container

#### Which issue this PR fixes

- fixes #462 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
