### PR TITLE
[jaeger-operator] feat: allow configuring container security context for jaeger operator

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.42.0
+version: 2.43.0
 appVersion: 1.43.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -53,27 +53,28 @@ The command removes all the Kubernetes components associated with the chart and 
 
 The following table lists the configurable parameters of the jaeger-operator chart and their default values.
 
-| Parameter               | Description                                                                                                 | Default                         |
-| :---------------------- | :---------------------------------------------------------------------------------------------------------- | :------------------------------ |
-| `serviceExtraLabels`    | Additional labels to jaeger-operator service  | `{}`
-| `extraLabels`           | Additional labels to jaeger-operator deployment  | `{}`
-| `image.repository`      | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`             | Controller container image tag                                                                              | `1.43.0`                        |
-| `image.pullPolicy`      | Controller container image pull policy                                                                      | `IfNotPresent`                  |
-| `jaeger.create`         | Jaeger instance will be created                                                                             | `false`                         |
-| `jaeger.spec`           | Jaeger instance specification                                                                               | `{}`                            |
-| `rbac.create`           | All required roles and rolebindings will be created                                                         | `true`                          |
-| `serviceAccount.create` | Service account to use                                                                                      | `true`                          |
-| `rbac.pspEnabled`       | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
-| `rbac.clusterRole`      | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
-| `serviceAccount.name`   | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
-| `extraEnv`              | Additional environment variables passed to the operator. For example:   name: LOG-LEVEL   value: debug      | `[]`                            |
-| `resources`             | K8s pod resources                                                                                           | `None`                          |
-| `nodeSelector`          | Node labels for pod assignment                                                                              | `{}`                            |
-| `tolerations`           | Toleration labels for pod assignment                                                                        | `[]`                            |
-| `affinity`              | Affinity settings for pod assignment                                                                        | `{}`                            |
-| `securityContext`       | Security context for pod                                                                                    | `{}`                            |
-| `priorityClassName`     | Priority class name for the pod                                                                             | `None`                          |
+| Parameter                  | Description                                                                                                 | Default                         |
+|-:--------------------------|-:-----------------------------------------------------------------------------------------------------------|-:-------------------------------|
+| `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
+| `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
+| `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
+| `image.tag`                | Controller container image tag                                                                              | `1.43.0`                        |
+| `image.pullPolicy`         | Controller container image pull policy                                                                      | `IfNotPresent`                  |
+| `jaeger.create`            | Jaeger instance will be created                                                                             | `false`                         |
+| `jaeger.spec`              | Jaeger instance specification                                                                               | `{}`                            |
+| `rbac.create`              | All required roles and rolebindings will be created                                                         | `true`                          |
+| `serviceAccount.create`    | Service account to use                                                                                      | `true`                          |
+| `rbac.pspEnabled`          | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
+| `rbac.clusterRole`         | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
+| `serviceAccount.name`      | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
+| `extraEnv`                 | Additional environment variables passed to the operator. For example:   name: LOG-LEVEL   value: debug      | `[]`                            |
+| `resources`                | K8s pod resources                                                                                           | `None`                          |
+| `nodeSelector`             | Node labels for pod assignment                                                                              | `{}`                            |
+| `tolerations`              | Toleration labels for pod assignment                                                                        | `[]`                            |
+| `affinity`                 | Affinity settings for pod assignment                                                                        | `{}`                            |
+| `securityContext`          | Security context for pod                                                                                    | `{}`                            |
+| `containerSecurityContext` | Security context for the container                                                                          | `{}`                            |
+| `priorityClassName`        | Priority class name for the pod                                                                             | `None`                          |
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section.
 

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -80,6 +80,10 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- with .Values.containerSecurityContext }}
+          securityContext:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       volumes:
       - name: cert
         secret:

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -91,6 +91,8 @@ affinity: {}
 
 securityContext: {}
 
+containerSecurityContext: {}
+
 priorityClassName:
 
 # Specifies weather host network should be used


### PR DESCRIPTION
#### What this PR does

Allows configuring the security context for jaeger operator container. This enables configuration of options such as `capabilities`, `allowPriviledgeEscalation`, etc which are required in many platforms, orgs and while using the new restricted Pod security admission mode.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
