### PR TITLE
[jaeger-operator] Fix table in README.md

### DIFF
--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -54,7 +54,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the jaeger-operator chart and their default values.
 
 | Parameter                  | Description                                                                                                 | Default                         |
-|-:--------------------------|-:-----------------------------------------------------------------------------------------------------------|-:-------------------------------|
+|----------------------------|-------------------------------------------------------------------------------------------------------------|---------------------------------|
 | `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |


### PR DESCRIPTION
#### What this PR does
Fixes the table in the jaeger-operator Readme

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
