### PR TITLE
[jaeger] tenant app/chart version upgrade to match operator

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.70.0
+version: 0.71.0
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.42.0
+appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.69.1
+version: 0.70.0
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

Upgrades Jaeger tenant Helm chart version and AppVersion which is used by the values file for default image.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
