### PR TITLE
[jaeger] Updating kafka chart dependency from 19.x to 22.x

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -36,7 +36,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^19.1.5
+    version: ^22.1.3
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.0
+version: 0.71.1
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:


### PR DESCRIPTION
#### What this PR does
Updating Kafka chart dependency to latest tag which fixes issues with kafka starting up with latest bitnami tags

#### Which issue this PR fixes

Seeing below messages in pod logs and Kafka doesn't startup
kafka 17:30:38.04 INFO  ==> ** Starting Kafka setup **
kafka 17:30:38.09 WARN  ==> KAFKA_CFG_LISTENERS must include a listener for CONTROLLER
kafka 17:30:38.10 WARN  ==> You set the environment variable ALLOW_PLAINTEXT_LISTENER=yes. For safety reasons, do not use this flag in a production environment.
kafka 17:30:38.11 INFO  ==> Initializing Kafka...
kafka 17:30:38.12 INFO  ==> No injected configuration files found, creating default config files
kafka 17:30:38.56 INFO  ==> Configuring Kafka for inter-broker communications with PLAINTEXT authentication.
kafka 17:30:38.56 WARN  ==> Inter-broker communications are configured as PLAINTEXT. This is not safe for production environments.
kafka 17:30:38.57 INFO  ==> Configuring Kafka for client communications with PLAINTEXT authentication.
kafka 17:30:38.57 WARN  ==> Client communications are configured using PLAINTEXT listeners. For safety reasons, do not use this in a production environment.
kafka 17:30:38.58 INFO  ==> Initializing KRaft...
kafka 17:30:38.58 WARN  ==> KAFKA_KRAFT_CLUSTER_ID not set - If using multiple nodes then you must use the same Cluster ID for each one
kafka 17:30:39.75 INFO  ==> Generated Kafka cluster ID 'vCUt2zk3RcOpne7N1'
kafka 17:30:39.75 INFO  ==> Formatting storage directories to add metadata...

- fixes #
With latest tag, Kafka has below fix that will resolve the issue with start up
https://github.com/bitnami/charts/pull/16558

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
