### PR TITLE
[jaeger] Add option to configure ingester only via environment variables

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.3
+version: 0.71.4
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -66,12 +66,18 @@ spec:
           - name: SPAN_STORAGE_TYPE
             value: {{ .Values.storage.type }}
           {{- include "storage.env" . | nindent 10 }}
+          {{ if .Values.storage.kafka.brokers }}
           - name: KAFKA_CONSUMER_BROKERS
             value: {{ tpl (include "helm-toolkit.utils.joinListWithComma" .Values.storage.kafka.brokers) . }}
+          {{- end }}
+          {{ if .Values.storage.kafka.topic }}
           - name: KAFKA_CONSUMER_TOPIC
             value: {{ .Values.storage.kafka.topic }}
+          {{- end }}
+          {{ if .Values.storage.kafka.authentication }}
           - name: KAFKA_CONSUMER_AUTHENTICATION
             value: {{ .Values.storage.kafka.authentication }}
+          {{- end }}
         ports:
         - containerPort: 14270
           name: admin


### PR DESCRIPTION
#### What this PR does

Until now it was not possible to configure brokers, topic and authentication via environment variables because there where always environment variables added that sourced the values from the `values.yaml` file.

When the configuration values are only available through ConfigMaps this is not possible to provide via `values.yaml`.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
