### PR TITLE
[jaeger] Fix otlp service regression in 0.71.5

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.5
+version: 0.71.6
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -119,10 +119,10 @@ spec:
         {{- end }}
         {{- if or .Values.collector.service.otlp.grpc .Values.collector.service.otlp.http }}
         - containerPort: {{ default 4317 .Values.collector.service.otlp.grpc.port }}
-          name: otlp-grpc
+          name: {{ .Values.collector.service.otlp.grpc.name }}
           protocol: TCP
         - containerPort: {{ default 4318 .Values.collector.service.otlp.http.port }}
-          name: otlp-http
+          name: {{ .Values.collector.service.otlp.http.name }}
           protocol: TCP
         {{- end }}
         readinessProbe:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -36,9 +36,9 @@ allInOne:
     collector:
       otlp:
         grpc:
-          name: otlp-grpc
+          name: grpc-otlp
         http:
-          name: otlp-http
+          name: http-otlp
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -379,11 +379,11 @@ collector:
       # nodePort:
     otlp:
       grpc:
-        name: otlp-grpc
+        name: grpc-otlp
         # port: 4317
         # nodePort:
       http:
-        name: otlp-grpc
+        name: http-otlp
         # port: 4318
         # nodePort:
   ingress:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -36,9 +36,9 @@ allInOne:
     collector:
       otlp:
         grpc:
-          name: gtpc-otlp
+          name: otlp-grpc
         http:
-          name: http-otlp
+          name: otlp-http
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -379,11 +379,11 @@ collector:
       # nodePort:
     otlp:
       grpc:
-        name: grpc-otlp
+        name: otlp-grpc
         # port: 4317
         # nodePort:
       http:
-        name: http-otlp
+        name: otlp-grpc
         # port: 4318
         # nodePort:
   ingress:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -36,9 +36,9 @@ allInOne:
     collector:
       otlp:
         grpc:
-          name: grpc-otlp
+          name: otlp-grpc
         http:
-          name: http-otlp
+          name: otlp-http
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -379,11 +379,11 @@ collector:
       # nodePort:
     otlp:
       grpc:
-        name: grpc-otlp
+        name: otlp-grpc
         # port: 4317
         # nodePort:
       http:
-        name: http-otlp
+        name: otlp-http
         # port: 4318
         # nodePort:
   ingress:


### PR DESCRIPTION
Version 0.71.5 added configurable otlp port names to the collector service, but introduced some typos, which break otlp for http & gRPC. I'm not sure why they would be configurable, so I haven't also made the port names on the actual deployment configurable to match the service, but at least this should fix connectivity
Signed-off-by: Jon Bates <jonathan.bates@team.bumble.com>

#### What this PR does
Fixes regression in 0.71.5

#### Which issue this PR fixes
Can't see one that has been raised

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
