### PR TITLE
[jaeger] Configure collector and ingester HPAs to only deploy if component is enabled

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.7
+version: 0.71.8
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/collector-hpa.yaml
+++ b/charts/jaeger/templates/collector-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.collector.autoscaling.enabled }}
+{{- if and .Values.collector.enabled .Values.collector.autoscaling.enabled }}
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:

--- a/charts/jaeger/templates/ingester-hpa.yaml
+++ b/charts/jaeger/templates/ingester-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.ingester.autoscaling.enabled }}
+{{- if and .Values.ingester.enabled .Values.ingester.autoscaling.enabled }}
 apiVersion: {{ include "common.capabilities.hpa.apiVersion" ( dict "context" $ ) }}
 kind: HorizontalPodAutoscaler
 metadata:


### PR DESCRIPTION
#### What this PR does

Configured the collector and ingester HPA resources to additionally only deploy if components themselves are enabled. 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
