### PR TITLE
[jaeger-operator]: Fixed support for custom ports

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.46.0
+version: 2.46.1
 appVersion: 1.46.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -50,12 +50,15 @@ spec:
             name: metrics
           - containerPort: {{ .Values.webhooks.port }}
             name: webhook-server
-            protocol: TCP  
+            protocol: TCP
           volumeMounts:
           - mountPath: /tmp/k8s-webhook-server/serving-certs
             name: cert
             readOnly: true
-          args: ["start"]
+          args:
+            - start
+            - {{ printf "--metrics-port=%v" .Values.metricsPort }}
+            - {{ printf "--webhook-bind-port=%v" .Values.webhooks.port }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.rbac.clusterRole }}


### PR DESCRIPTION
#### What this PR does

This PR sets the `--metrics-port` & `--webhook-bind-port` so if these values are changed from the default the operator continues to work correctly.

#### Which issue this PR fixes

- Fixes #473

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
