### PR TITLE
[jaeger operator] Fix Parameters table on README.md

### DIFF
--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -2,6 +2,7 @@ The following table shows the compatibility of `Jaeger Operator helm chart` with
 
 | Chart version             | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |---------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.46.1                    | v1.47.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.46.0                    | v1.46.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.45.0                    | v1.45.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.42.0                    | v1.43.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.46.1
+version: 2.46.2
 appVersion: 1.46.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`                | Controller container image tag                                                                              | `1.46.0`                        |
+| `image.tag`                | Controller container image tag                                                                              | `1.47.0`                        |
 | `image.pullPolicy`         | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`            | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`              | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -54,7 +54,7 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the jaeger-operator chart and their default values.
 
 | Parameter                  | Description                                                                                                 | Default                         |
-|-:--------------------------|-:-----------------------------------------------------------------------------------------------------------|-:-------------------------------|
+|---------------------------:|-------------------------------------------------------------------------------------------------------------|---------------------------------|
 | `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
@@ -67,7 +67,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `rbac.pspEnabled`          | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
 | `rbac.clusterRole`         | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
 | `serviceAccount.name`      | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
-| `extraEnv`                 | Additional environment variables passed to the operator. For example:   name: LOG-LEVEL   value: debug      | `[]`                            |
+| `extraEnv`                 | Additional environment variables passed to the operator. For example: name: LOG-LEVEL value: debug          | `[]`                            |
 | `resources`                | K8s pod resources                                                                                           | `None`                          |
 | `nodeSelector`             | Node labels for pod assignment                                                                              | `{}`                            |
 | `tolerations`              | Toleration labels for pod assignment                                                                        | `[]`                            |

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.46.0
+  tag: 1.47.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does

Fixes table formating for the README.md file
---

## Previous table visualization

<img width="1069" alt="image" src="https://github.com/jaegertracing/helm-charts/assets/20484959/6cd27f89-6ab9-4901-bf3e-9ce38055cee3">

## After fixes

<img width="1042" alt="image" src="https://github.com/jaegertracing/helm-charts/assets/20484959/ffa47bde-4fde-4acf-bb4e-d7f9a48c9d39">
