### PR TITLE
[jaeger] extraSecretMounts for all-in-one configuration

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.8
+version: 0.71.9
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -311,7 +311,7 @@ query:
   enabled: false
 ```
 
-It's possible to specify resources and extra environment variables for the all in one deployment:
+It's possible to specify resources, extra environment variables, and extra secrets for the all in one deployment:
 
 ```yaml
 allInOne:
@@ -325,6 +325,12 @@ allInOne:
     requests:
       cpu: 256m
       memory: 128Mi
+  extraSecretMounts:
+    - name: jaeger-tls
+      mountPath: /tls
+      subPath: ""
+      secretName: jaeger-tls
+      readOnly: true
 ```
 
 ```bash

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -98,18 +98,28 @@ spec:
           resources:
         {{- toYaml . | nindent 12 }}
       {{- end }}
-
-        {{- if .Values.allInOne.samplingConfig}}
           volumeMounts:
+        {{- if .Values.allInOne.samplingConfig}}
             - name: strategies
               mountPath: /etc/conf/
         {{- end }}
+        {{- range .Values.allInOne.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              subPath: {{ .subPath }}
+              readOnly: {{ .readOnly }}
+        {{- end }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
-    {{- if .Values.allInOne.samplingConfig}}
       volumes:
+    {{- if .Values.allInOne.samplingConfig}}
         - name: strategies
           configMap:
             name: {{ include "jaeger.fullname" . }}-sampling-strategies
+    {{- end }}
+    {{- range .Values.allInOne.extraSecretMounts }}
+        - name: {{ .name }}
+          secret:
+            secretName: {{ .secretName }}
     {{- end }}
     {{- with .Values.allInOne.nodeSelector }}
       nodeSelector:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -21,6 +21,12 @@ allInOne:
   image: jaegertracing/all-in-one
   pullPolicy: IfNotPresent
   extraEnv: []
+  extraSecretMounts: []
+    # - name: jaeger-tls
+    #   mountPath: /tls
+    #   subPath: ""
+    #   secretName: jaeger-tls
+    #   readOnly: true
   # command line arguments / CLI flags
   # See https://www.jaegertracing.io/docs/cli/
   args: []


### PR DESCRIPTION
#### What this PR does
This PR adds the ability to mount secrets to the all-in-one deployment through the `.Values.allInOne.extraSecretMounts` value. Implementation follows the implementation in [collector-deploy.yaml](https://github.com/jaegertracing/helm-charts/blob/main/charts/jaeger/templates/collector-deploy.yaml).

#### Which issue this PR fixes
- fixes #484 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
