### PR TITLE
[jaeger] Unset default collector OTLP ports

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.9
+version: 0.71.10
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -68,7 +68,6 @@ spec:
           {{- if or .Values.collector.service.otlp.grpc .Values.collector.service.otlp.http }}
           - name: COLLECTOR_OTLP_ENABLED
             value: "true"
-          {{- end }}
           {{- if ne (default 4317 .Values.collector.service.otlp.grpc.port | toString ) "4317" }}
           - name: COLLECTOR_OTLP_GRPC_HOST_PORT
             value: {{ .Values.collector.service.otlp.grpc.port | quote }}
@@ -76,6 +75,7 @@ spec:
           {{- if ne (default 4318 .Values.collector.service.otlp.http.port | toString) "4318" }}
           - name: COLLECTOR_OTLP_HTTP_HOST_PORT
             value: {{ .Values.collector.service.otlp.http.port | quote }}
+          {{- end }}
           {{- end }}
           {{- if .Values.ingester.enabled }}
           - name: SPAN_STORAGE_TYPE

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -388,12 +388,12 @@ collector:
       # port: 9411
       # nodePort:
     otlp:
-      grpc:
-        name: otlp-grpc
+      grpc: {}
+        # name: otlp-grpc
         # port: 4317
         # nodePort:
-      http:
-        name: otlp-http
+      http: {}
+        # name: otlp-http
         # port: 4318
         # nodePort:
   ingress:


### PR DESCRIPTION
#### What this PR does

This sets the default values of the `collector.service.otlp.grpc` and `collector.service.otlp.http` to `{}` and also fixes a bug with the service logic that would prevent overriding these values with `null`. At the very least, the service change is needed because the values cannot be overridden with `null` and helm does not allow overriding them with `{}` (see https://github.com/helm/helm/issues/5407).

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
