### PR TITLE
[jaeger] make replicas a Helm value instead of hardcoding it

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.10
+version: 0.71.11
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -9,7 +9,9 @@ metadata:
     prometheus.io/port: "14269"
     prometheus.io/scrape: "true"
 spec:
-  replicas: 1
+  {{- if .Values.allInOne.replicas }}
+  replicas: {{ .Values.allInOne.replicas }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -18,6 +18,7 @@ fullnameOverride: ""
 
 allInOne:
   enabled: false
+  replicas: 1
   image: jaegertracing/all-in-one
   pullPolicy: IfNotPresent
   extraEnv: []


### PR DESCRIPTION
#### What this PR does

Adds a Helm value for `allInOne.replicas`.

#### Which issue this PR fixes

- fixes #493

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
