### PR TITLE
[jaeger] Bumping kafka chart dependency from 19.x to 24.x

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.11
+version: 0.71.12
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:
@@ -36,7 +36,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^19.1.5
+    version: ^24.0.5
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.10
+version: 0.71.11
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -9,7 +9,9 @@ metadata:
     prometheus.io/port: "14269"
     prometheus.io/scrape: "true"
 spec:
-  replicas: 1
+  {{- if .Values.allInOne.replicas }}
+  replicas: {{ .Values.allInOne.replicas }}
+  {{- end }}
   strategy:
     type: Recreate
   selector:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -18,6 +18,7 @@ fullnameOverride: ""
 
 allInOne:
   enabled: false
+  replicas: 1
   image: jaegertracing/all-in-one
   pullPolicy: IfNotPresent
   extraEnv: []


### PR DESCRIPTION
#### What this PR does
Bumps kafka tag to use latest bitnami image

#### Which issue this PR fixes
Updating Kafka chart dependency to latest tag which fixes issues with kafka starting up with latest bitnami tags

Which issue this PR fixes
Seeing below messages in pod logs and Kafka doesn't startup
kafka 17:30:38.04 INFO ==> ** Starting Kafka setup **
kafka 17:30:38.09 WARN ==> KAFKA_CFG_LISTENERS must include a listener for CONTROLLER
kafka 17:30:38.10 WARN ==> You set the environment variable ALLOW_PLAINTEXT_LISTENER=yes. For safety reasons, do not use this flag in a production environment.
kafka 17:30:38.11 INFO ==> Initializing Kafka...
kafka 17:30:38.12 INFO ==> No injected configuration files found, creating default config files
kafka 17:30:38.56 INFO ==> Configuring Kafka for inter-broker communications with PLAINTEXT authentication.
kafka 17:30:38.56 WARN ==> Inter-broker communications are configured as PLAINTEXT. This is not safe for production environments.
kafka 17:30:38.57 INFO ==> Configuring Kafka for client communications with PLAINTEXT authentication.
kafka 17:30:38.57 WARN ==> Client communications are configured using PLAINTEXT listeners. For safety reasons, do not use this in a production environment.
kafka 17:30:38.58 INFO ==> Initializing KRaft...
kafka 17:30:38.58 WARN ==> KAFKA_KRAFT_CLUSTER_ID not set - If using multiple nodes then you must use the same Cluster ID for each one
kafka 17:30:39.75 INFO ==> Generated Kafka cluster ID 'vCUt2zk3RcOpne7N1'
kafka 17:30:39.75 INFO ==> Formatting storage directories to add metadata...

kafka 14:39:41.05 
kafka 14:39:41.05 Welcome to the Bitnami kafka container
kafka 14:39:41.05 Subscribe to project updates by watching https://github.com/bitnami/containers
kafka 14:39:41.06 Submit issues and feature requests at https://github.com/bitnami/containers/issues
kafka 14:39:41.06 
kafka 14:39:41.06 INFO  ==> ** Starting Kafka setup **
kafka 14:39:41.09 DEBUG ==> Validating settings in KAFKA_* env vars...
kafka 14:39:41.09 ERROR ==> KRaft requires KAFKA_CFG_NODE_ID to be set for the quorum controller
/opt/bitnami/scripts/libkafka.sh: line 258: KAFKA_CFG_NODE_ID: unbound variable


- fixes #
Kafka fixed few issues with latest image:
https://github.com/bitnami/containers/issues/33271
This new version is a refactor of the chart including several major changes in both the chart architecture and the bitnami/kafka image used.

You can find the upgrade notes here:

[Image notable changes](https://github.com/bitnami/containers/blob/main/bitnami/kafka/README.md#351-debian-11-r4-341-debian-11-r50-332-debian-11-r176-and-323-debian-11-r161)
[Kafka chart upgrading notes](https://github.com/bitnami/containers/blob/main/bitnami/kafka/README.md#351-debian-11-r4-341-debian-11-r50-332-debian-11-r176-and-323-debian-11-r161)

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
