### PR TITLE
[Jaeger] fix .allinone.replicas helm value

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.13
+version: 0.71.14
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.12
+version: 0.71.13
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -9,7 +9,7 @@ metadata:
     prometheus.io/port: "14269"
     prometheus.io/scrape: "true"
 spec:
-  {{- if .Values.allInOne.replicas }}
+  {{- if hasKey .Values.allInOne "replicas" }}
   replicas: {{ .Values.allInOne.replicas }}
   {{- end }}
   strategy:


### PR DESCRIPTION
#### This PR fixes the bug created after [PR#494](https://github.com/jaegertracing/helm-charts/pull/494) when helm chart value `.allInOne.replicas` is `0` but the deployment is still set to 1.

#### When the below if statement is computed for `replicas: 0`, the result is `false` and as a consequence the deployment manifest doesn't contain `replicas` field, which in turn forces it to use the default value, which is `1`.
```yaml
spec:
  {{- if .Values.allInOne.replicas }}
  replicas: {{ .Values.allInOne.replicas }}
  {{- end }}
```

- fixes # Rather than checking value of `replicas`, we can check if `.allInOne.replicas` key has been declared. This would create a deployment with the specified number of replicas in the values file.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
