### PR TITLE
[jaeger] Revert - Bumping kafka chart dependency from 19.x to 24.x

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.12
+version: 0.71.13
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:
@@ -36,7 +36,7 @@ dependencies:
     repository: https://helm.elastic.co
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^24.0.10
+    version: ^19.1.5
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common


### PR DESCRIPTION
#### What this PR does
Reverting Kafka chart version as new version is not working as expected and having issues with ingester/collector pods coming online due to Kafka SSL handshake issues. New kafka chart had major design changes migrating from Zookeeper to KRaft mode.

```
Ingester/Collector pod logs

"error":"kafka: client has run out of available brokers to talk to: EOF"
```

#### Which issue this PR fixes

reverting kafka to old chart which is working, reverting this [PR](https://github.com/jaegertracing/helm-charts/pull/498/files) which was merged

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
