### PR TITLE
[jaeger-operator] Bump jaeger-operator and helm chart

### DIFF
--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -2,6 +2,7 @@ The following table shows the compatibility of `Jaeger Operator helm chart` with
 
 | Chart version             | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |---------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.47.0                    | v1.47.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.46.0                    | v1.46.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.45.0                    | v1.45.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |
 | 2.42.0                    | v1.43.x         | v1.19 to v1.26  | v0.23              | v1.6.1+      |

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.46.2
-appVersion: 1.46.0
+version: 2.47.0
+appVersion: 1.47.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -58,7 +58,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`                | Controller container image tag                                                                              | `1.46.0`                        |
+| `image.tag`                | Controller container image tag                                                                              | `1.47.0`                        |
 | `image.pullPolicy`         | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`            | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`              | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.46.0
+  tag: 1.47.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does

Bump jaeger operator image and helm chart versions to `1.47.0`

#### Which issue this PR fixes

N/A

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
