### PR TITLE
[jaeger] Add resources to oAuthSidecar

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.14
+version: 0.71.15
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -351,6 +351,7 @@ query:
   enabled: true
   oAuthSidecar:
     enabled: true
+    resources: {}
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
     pullPolicy: IfNotPresent
     containerPort: 4180

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -162,6 +162,8 @@ spec:
         ports:
           - containerPort: {{ .Values.query.oAuthSidecar.containerPort }}
             name: oauth-proxy
+        resources:
+          {{- toYaml .Values.query.oAuthSidecar.resources | nindent 10 }}
         {{- if .Values.query.oAuthSidecar.livenessProbe }}
         livenessProbe:
           {{- toYaml .Values.query.oAuthSidecar.livenessProbe | nindent 10 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -512,6 +512,13 @@ query:
   basePath: /
   oAuthSidecar:
     enabled: false
+    resources: {}
+      # limits:
+      #   cpu: 500m
+      #   memory: 512Mi
+      # requests:
+      #   cpu: 256m
+      #   memory: 128Mi
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
     pullPolicy: IfNotPresent
     containerPort: 4180


### PR DESCRIPTION
[jaeger] Add resources to oAuthSidecar to allow setting in case of quota requirements

#### What this PR does
It updates the `charts/jaeger/templates/query-deploy.yaml` to add the ability to set resources via a values.yaml.

#### Which issue this PR fixes
Could not deploy with Oauth2 proxy sidecar in an environment that enforces quotas without manual config modifications.

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
