### PR TITLE
[jaeger] Added imagePullSecrets option for all-in-one deployment.

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.15
+version: 0.71.16
 # CronJobs require v1.21
 kubeVersion: '>= 1.21-0'
 keywords:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -30,6 +30,10 @@ spec:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
     spec:
+      {{- with .Values.allInOne.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}    
       containers:
         - env:
           {{- if .Values.allInOne.extraEnv }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -20,6 +20,7 @@ allInOne:
   enabled: false
   replicas: 1
   image: jaegertracing/all-in-one
+  imagePullSecrets: []
   pullPolicy: IfNotPresent
   extraEnv: []
   extraSecretMounts: []


### PR DESCRIPTION
#### What this PR does
For a project I require using a different repo for the all-in-one image, requiring pull secrets. This PR adds the ability to set these in the chart values.

#### Which issue this PR fixes
-

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values -> Not done, as the readme doesn't specify repository settings of the all-in-one image.
