### PR TITLE
[jaeger] more flexible TLS variables

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,9 +3,9 @@ appVersion: 1.45.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.17
+version: 0.71.18
 # CronJobs require v1.21
-kubeVersion: '>= 1.21-0'
+kubeVersion: ">= 1.21-0"
 keywords:
   - jaeger
   - opentracing

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -365,7 +365,7 @@ Elasticsearch related environment variables
 - name: ES_TLS_ENABLED
   value: "true"
 - name: ES_TLS_CA
-  value: /es-tls/ca-cert.pem
+  value: {{ .Values.storage.elasticsearch.tls.ca }}
 {{- end }}
 {{- if .Values.storage.elasticsearch.indexPrefix }}
 - name: ES_INDEX_PREFIX

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -167,8 +167,8 @@ spec:
         {{- end }}
         {{- if .Values.storage.elasticsearch.tls.enabled }}
           - name: {{ .Values.storage.elasticsearch.tls.secretName }}
-            mountPath: "/es-tls/ca-cert.pem"
-            subPath: "ca-cert.pem"
+            mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+            subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
             readOnly: true
         {{- end }}
         {{- if .Values.collector.samplingConfig}}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -76,8 +76,8 @@ spec:
             {{- end }}
             {{- if .Values.storage.elasticsearch.tls.enabled }}
               - name: {{ .Values.storage.elasticsearch.tls.secretName }}
-                mountPath: "/es-tls/ca-cert.pem"
-                subPath: "ca-cert.pem"
+                mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+                subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
           restartPolicy: OnFailure

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -90,8 +90,8 @@ spec:
             {{- end }}
             {{- if .Values.storage.elasticsearch.tls.enabled }}
               - name: {{ .Values.storage.elasticsearch.tls.secretName }}
-                mountPath: "/es-tls/ca-cert.pem"
-                subPath: "ca-cert.pem"
+                mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+                subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
           volumes:

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -90,8 +90,8 @@ spec:
             {{- end }}
             {{- if .Values.storage.elasticsearch.tls.enabled }}
               - name: {{ .Values.storage.elasticsearch.tls.secretName }}
-                mountPath: "/es-tls/ca-cert.pem"
-                subPath: "ca-cert.pem"
+                mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+                subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
           volumes:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -114,8 +114,8 @@ spec:
         {{- end }}
         {{- if .Values.storage.elasticsearch.tls.enabled }}
           - name: {{ .Values.storage.elasticsearch.tls.secretName }}
-            mountPath: "/es-tls/ca-cert.pem"
-            subPath: "ca-cert.pem"
+            mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+            subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
             readOnly: true
         {{- end }}
         {{- if .Values.query.config}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -23,7 +23,8 @@ allInOne:
   imagePullSecrets: []
   pullPolicy: IfNotPresent
   extraEnv: []
-  extraSecretMounts: []
+  extraSecretMounts:
+    []
     # - name: jaeger-tls
     #   mountPath: /tls
     #   subPath: ""
@@ -96,7 +97,8 @@ storage:
     ## Use existing secret (ignores previous password)
     # existingSecret:
     ## Cassandra related env vars to be configured on the concerned components
-    extraEnv: []
+    extraEnv:
+      []
       # - name: CASSANDRA_SERVERS
       #   value: cassandra
       # - name: CASSANDRA_PORT
@@ -106,7 +108,8 @@ storage:
       # - name: CASSANDRA_TLS_ENABLED
       #   value: "false"
     ## Cassandra related cmd line opts to be configured on the concerned components
-    cmdlineParams: {}
+    cmdlineParams:
+      {}
       # cassandra.servers: cassandra
       # cassandra.port: 9042
       # cassandra.keyspace: jaeger_v1_test
@@ -126,20 +129,27 @@ storage:
     nodesWanOnly: false
     extraEnv: []
     ## ES related env vars to be configured on the concerned components
-      # - name: ES_SERVER_URLS
-      #   value: http://elasticsearch-master:9200
-      # - name: ES_USERNAME
-      #   value: elastic
-      # - name: ES_INDEX_PREFIX
-      #   value: test
+    # - name: ES_SERVER_URLS
+    #   value: http://elasticsearch-master:9200
+    # - name: ES_USERNAME
+    #   value: elastic
+    # - name: ES_INDEX_PREFIX
+    #   value: test
     ## ES related cmd line opts to be configured on the concerned components
-    cmdlineParams: {}
+    cmdlineParams:
+      {}
       # es.server-urls: http://elasticsearch-master:9200
       # es.username: elastic
       # es.index-prefix: test
     tls:
       enabled: false
       secretName: es-tls-secret
+      # The mount properties of the secret
+      mountPath: /es-tls/ca-cert.pem
+      subPath: ca-cert.pem
+      # How ES_TLS_CA variable will be set in the various components
+      ca: /es-tls/ca-cert.pem
+
   kafka:
     brokers:
       - kafka:9092
@@ -184,7 +194,8 @@ schema:
   image: jaegertracing/jaeger-cassandra-schema
   imagePullSecrets: []
   pullPolicy: IfNotPresent
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -202,7 +213,8 @@ schema:
   podSecurityContext: {}
   ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 300
-  extraEnv: []
+  extraEnv:
+    []
     # - name: MODE
     #   value: prod
     # - name: TRACE_TTL
@@ -237,7 +249,8 @@ ingester:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -283,7 +296,8 @@ agent:
   extraEnv: []
   daemonset:
     useHostPort: false
-    updateStrategy: {}
+    updateStrategy:
+      {}
       # type: RollingUpdate
       # rollingUpdate:
       #   maxUnavailable: 1
@@ -300,7 +314,8 @@ agent:
     binaryPort: 6832
     # samplingPort: (HTTP) serve configs, sampling strategies
     samplingPort: 5778
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -372,7 +387,7 @@ collector:
   service:
     annotations: {}
     # The IP to be used by the load balancer (if supported)
-    loadBalancerIP: ''
+    loadBalancerIP: ""
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
@@ -386,15 +401,18 @@ collector:
       port: 14268
       # nodePort:
     # can accept Zipkin spans in JSON or Thrift
-    zipkin: {}
+    zipkin:
+      {}
       # port: 9411
       # nodePort:
     otlp:
-      grpc: {}
+      grpc:
+        {}
         # name: otlp-grpc
         # port: 4317
         # nodePort:
-      http: {}
+      http:
+        {}
         # name: otlp-http
         # port: 4318
         # nodePort:
@@ -414,17 +432,18 @@ collector:
     #   - host: chart-example.local
     #     servicePort: grpc
     # annotations:
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger-collector
+    # app: jaeger-collector
     # tls:
-      # Secrets must be manually created in the namespace.
-      # - secretName: chart-example-tls
-      #   hosts:
-      #     - chart-example.local
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
     pathType:
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -513,7 +532,8 @@ query:
   basePath: /
   oAuthSidecar:
     enabled: false
-    resources: {}
+    resources:
+      {}
       # limits:
       #   cpu: 500m
       #   memory: 512Mi
@@ -543,13 +563,13 @@ query:
   securityContext: {}
   agentSidecar:
     enabled: true
-#    resources:
-#      limits:
-#        cpu: 500m
-#        memory: 512Mi
-#      requests:
-#        cpu: 256m
-#        memory: 128Mi
+  #    resources:
+  #      limits:
+  #        cpu: 500m
+  #        memory: 512Mi
+  #      requests:
+  #        cpu: 256m
+  #        memory: 128Mi
   annotations: {}
   image: jaegertracing/jaeger-query
   # tag: 1.22
@@ -581,19 +601,20 @@ query:
     # hosts:
     #   - chart-example.local
     # annotations:
-      # kubernetes.io/ingress.class: nginx
-      # kubernetes.io/tls-acme: "true"
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
     # labels:
-      # app: jaeger-query
+    # app: jaeger-query
     # tls:
-      # Secrets must be manually created in the namespace.
-      # - secretName: chart-example-tls
-      #   hosts:
-      #     - chart-example.local
+    # Secrets must be manually created in the namespace.
+    # - secretName: chart-example-tls
+    #   hosts:
+    #     - chart-example.local
     pathType:
     health:
       exposed: false
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -671,7 +692,8 @@ spark:
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -705,14 +727,16 @@ esIndexCleaner:
   imagePullSecrets: []
   pullPolicy: IfNotPresent
   cmdlineParams: {}
-  extraEnv: []
+  extraEnv:
+    []
     # - name: ROLLOVER
     #   value: 'true'
   schedule: "55 23 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -754,7 +778,8 @@ esRollover:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -777,7 +802,8 @@ esRollover:
   podLabels: {}
   # ttlSecondsAfterFinished: 120
   initHook:
-    extraEnv: []
+    extraEnv:
+      []
       # - name: SHARDS
       #   value: "3"
     annotations: {}
@@ -800,12 +826,13 @@ esLookback:
     - name: UNIT
       value: days
     - name: UNIT_COUNT
-      value: '7'
-  schedule: '5 0 * * *'
+      value: "7"
+  schedule: "5 0 * * *"
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources: {}
+  resources:
+    {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -864,7 +891,8 @@ hotrod:
     # Used to create Ingress record (should be used with service.type: ClusterIP).
     hosts:
       - chart-example.local
-    annotations: {}
+    annotations:
+      {}
       # kubernetes.io/ingress.class: nginx
       # kubernetes.io/tls-acme: "true"
     tls:
@@ -873,7 +901,8 @@ hotrod:
       #   hosts:
       #     - chart-example.local
     pathType:
-  resources: {}
+  resources:
+    {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following


### PR DESCRIPTION
#### What this PR does

Adds the possibility to mount a secret with TLS certificates & keys that contains more than one value. The standard secret mounted always expects the `ca-cert.pem` key to be present, which makes activating TLS complicated in non-default scenarios. 

#### Which issue this PR fixes

- Fixes #513 
- Possibly related to #443

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
