### PR TITLE
[jaeger] Jaeger version update

### DIFF
--- a/charts/jaeger/Chart.lock
+++ b/charts/jaeger/Chart.lock
@@ -1,0 +1,15 @@
+dependencies:
+- name: cassandra
+  repository: https://charts.helm.sh/incubator
+  version: 0.15.3
+- name: elasticsearch
+  repository: https://helm.elastic.co
+  version: 7.17.3
+- name: kafka
+  repository: https://charts.bitnami.com/bitnami
+  version: 19.1.5
+- name: common
+  repository: https://charts.bitnami.com/bitnami
+  version: 1.16.0
+digest: sha256:60d70b3966a1bb5b87d6679139138b5a79871c486a771953d527e083ea44d9df
+generated: "2023-11-02T23:28:35.315492-04:00"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.45.0
+appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.71.18
+version: 0.72.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

Updates to the latest Jaeger version.

It also includes the Chart.lock file to ensure the chart can do a [dependency build](https://helm.sh/docs/helm/helm_dependency_build/) based on the specified dependencies for local development.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
