### PR TITLE
[jaeger] Allow Jaeger ServiceAccounts to have annotations specified

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.72.0
+version: 0.73.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/allinone-sa.yaml
+++ b/charts/jaeger/templates/allinone-sa.yaml
@@ -6,4 +6,8 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: all-in-one
+  {{- with .Values.allInOne.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-index-cleaner-sa.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-sa.yaml
@@ -6,5 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: es-index-cleaner
+  {{- with .Values.esIndexCleaner.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.esIndexCleaner.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-sa.yaml
+++ b/charts/jaeger/templates/es-lookback-sa.yaml
@@ -6,5 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: es-lookback
+  {{- with .Values.esLookback.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.esLookback.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/hotrod-sa.yaml
+++ b/charts/jaeger/templates/hotrod-sa.yaml
@@ -6,5 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: hotrod
+  {{- with .Values.hotrod.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.hotrod.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/ingester-sa.yaml
+++ b/charts/jaeger/templates/ingester-sa.yaml
@@ -6,5 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingester
+  {{- with .Values.ingester.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.ingester.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/templates/spark-sa.yaml
+++ b/charts/jaeger/templates/spark-sa.yaml
@@ -6,5 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: spark
+  {{- with .Values.spark.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 automountServiceAccountToken: {{ .Values.spark.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -40,6 +40,8 @@ allInOne:
   #       "param": 1
   #     }
   #   }
+  serviceAccount:
+    annotations: {}
   service:
     headless: true
     collector:
@@ -261,6 +263,7 @@ ingester:
     create: true
     # Explicitly mounts the API credentials for the Service Account
     automountServiceAccountToken: false
+    annotations: {}
     name:
   nodeSelector: {}
   tolerations: []
@@ -702,6 +705,7 @@ spark:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    annotations: {}
     # Explicitly mounts the API credentials for the Service Account
     automountServiceAccountToken: false
     name:
@@ -746,6 +750,7 @@ esIndexCleaner:
   numberOfDays: 7
   serviceAccount:
     create: true
+    annotations: {}
     # Explicitly mounts the API credentials for the Service Account
     automountServiceAccountToken: false
     name:
@@ -841,6 +846,7 @@ esLookback:
     #   memory: 128Mi
   serviceAccount:
     create: true
+    annotations: {}
     # Explicitly mounts the API credentials for the Service Account
     automountServiceAccountToken: false
     name:
@@ -917,6 +923,7 @@ hotrod:
     create: true
     # Explicitly mounts the API credentials for the Service Account
     automountServiceAccountToken: false
+    annotations: {}
     name:
   nodeSelector: {}
   tolerations: []


### PR DESCRIPTION
#### What this PR does
Annotations for ServiceAccounts can now be specified with helm values

#### Which issue this PR fixes

- fixes #518 

#### Checklist

- [ * ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ * ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ * ] Chart Version bumped
- [ * ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ * ] README.md has been updated to match version/contain new values
