### PR TITLE
[jaeger] fix .Values.storage.elasticsearch.tls for es-rollover-hook

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.72.0
+version: 0.72.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -76,6 +76,12 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
           {{- end }}
+          {{- if .Values.storage.elasticsearch.tls.enabled }}
+            - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+              mountPath: {{ .Values.storage.elasticsearch.tls.mountPath }}
+              subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
+              readOnly: true
+          {{- end }}
       volumes:
       {{- range .Values.esRollover.extraConfigmapMounts }}
         - name: {{ .name }}
@@ -86,5 +92,10 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+      {{- end }}
+      {{- if .Values.storage.elasticsearch.tls.enabled }}
+        - name: {{ .Values.storage.elasticsearch.tls.secretName }}
+          secret:
+            secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
       {{- end }}
 {{- end -}}


### PR DESCRIPTION

#### What this PR does
This PR corrects the situation when the parameters `.Value.storage.elasticsearch.tls` did not work for `es-rollover-hook.yml`
Added a section for mounting a tls secret from elasticsearch parameters.

#### Which issue this PR fixes
- fixes https://github.com/jaegertracing/helm-charts/issues/521

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
