### PR TITLE
[JAEGER] Fill the `cmdlineParams` property of the `esIndexCleaner` to enable its functionality.

### DIFF
--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -726,7 +726,9 @@ esIndexCleaner:
   image: jaegertracing/jaeger-es-index-cleaner
   imagePullSecrets: []
   pullPolicy: IfNotPresent
-  cmdlineParams: {}
+  cmdlineParams: 
+    {}
+    # index-prefix: test
   extraEnv:
     []
     # - name: ROLLOVER


### PR DESCRIPTION
#### What this PR does

I have encountered difficulties in determining the root cause of the unexpected behavior exhibited by esIndexCleaner.

```sh
{"level":"info","ts":1701136500.6844676,"caller":"es-index-cleaner/main.go:89","msg":"Indices before this date will be deleted","date":"2023-11-24T00:00:00Z"}
{"level":"info","ts":1701136500.6845164,"caller":"es-index-cleaner/main.go:98","msg":"Queried indices","indices":null}
{"level":"info","ts":1701136500.6846325,"caller":"es-index-cleaner/main.go:102","msg":"No indices to delete"}
```

The reason why I spent several hours to fix this issue is that the `template.spec.containers` includes enviornment value **ES_SERVER_URLS** and **ES_INDEX_PREFIX**. I didn't expect that this env vars are not related with the processor at all.

To enhance clarity, I think we should put index-prefix options into the values.yml file.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
