### PR TITLE
[jaeger] define securityContext for each resources 

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -14,6 +14,7 @@ keywords:
 home: https://jaegertracing.io
 icon: https://camo.githubusercontent.com/afa87494e0753b4b1f5719a2f35aa5263859dffb/687474703a2f2f6a61656765722e72656164746865646f63732e696f2f656e2f6c61746573742f696d616765732f6a61656765722d766563746f722e737667
 sources:
+  - https://github.com/jaegertracing/helm-charts
   - https://hub.docker.com/u/jaegertracing/
 maintainers:
   - name: dvonthenen

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.72.1
+version: 0.72.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.72.2
+version: 0.73.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -32,8 +32,6 @@ spec:
         {{- toYaml .Values.agent.podLabels | nindent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
       {{- if .Values.agent.useHostNetwork }}
       hostNetwork: true
       {{- end }}
@@ -52,8 +50,6 @@ spec:
       {{- end}}
       containers:
       - name: {{ template "jaeger.agent.name" . }}
-        securityContext:
-          {{- toYaml .Values.agent.securityContext | nindent 10 }}
         image: {{ .Values.agent.image }}:{{- .Values.agent.tag | default (include "jaeger.image.tag" .) }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
         args:
@@ -105,8 +101,15 @@ spec:
           httpGet:
             path: /
             port: admin
+        {{- if .Values.agent.resources }}
         resources:
-          {{- toYaml .Values.agent.resources | nindent 10 }}
+        {{- toYaml .Values.agent.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.agent.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.agent.securityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.agent.extraConfigmapMounts) (.Values.agent.extraSecretMounts) }}
         volumeMounts:
         {{- range .Values.agent.extraConfigmapMounts }}
           - name: {{ .name }}
@@ -120,6 +123,12 @@ spec:
             subPath: {{ .subPath }}
             readOnly: {{ .readOnly }}
         {{- end }}
+        {{- end }}
+      {{- if or (.Values.agent.podSecurityContext) (.Values.podSecurityContext) }}
+      securityContext:
+      {{- merge .Values.podSecurityContext .Values.agent.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.agent.extraConfigmapMounts) (.Values.agent.extraSecretMounts) }}
       volumes:
       {{- range .Values.agent.extraConfigmapMounts }}
         - name: {{ .name }}
@@ -130,6 +139,7 @@ spec:
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
+      {{- end }}
       {{- end }}
     {{- with .Values.agent.nodeSelector }}
       nodeSelector:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -100,12 +100,17 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 1
-      {{- with .Values.allInOne.resources }}
+        {{- with .Values.allInOne.resources }}
           resources:
         {{- toYaml . | nindent 12 }}
-      {{- end }}
+        {{- end }}
+        {{- if or (.Values.allInOne.securityContext) (.Values.securityContext) }}
+          securityContext:
+        {{- merge .Values.securityContext .Values.allInOne.securityContext | toYaml | nindent 12 }}
+        {{- end }}
+        {{- if or (.Values.allInOne.samplingConfig) (.Values.allInOne.extraSecretMounts) }}
           volumeMounts:
-        {{- if .Values.allInOne.samplingConfig}}
+        {{- if .Values.allInOne.samplingConfig }}
             - name: strategies
               mountPath: /etc/conf/
         {{- end }}
@@ -115,20 +120,27 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
         {{- end }}
+        {{- end }}
+      {{- if or (.Values.allInOne.podSecurityContext) (.Values.podSecurityContext) }}
+      securityContext:
+      {{- merge .Values.podSecurityContext .Values.allInOne.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
+      {{- if or (.Values.allInOne.samplingConfig) (.Values.allInOne.extraSecretMounts)}}
       volumes:
-    {{- if .Values.allInOne.samplingConfig}}
+       {{- if .Values.allInOne.samplingConfig}}
         - name: strategies
           configMap:
             name: {{ include "jaeger.fullname" . }}-sampling-strategies
-    {{- end }}
-    {{- range .Values.allInOne.extraSecretMounts }}
+      {{- end }}
+      {{- range .Values.allInOne.extraSecretMounts }}
         - name: {{ .name }}
           secret:
             secretName: {{ .secretName }}
-    {{- end }}
-    {{- with .Values.allInOne.nodeSelector }}
+      {{- end }}
+      {{- end }}
+      {{- with .Values.allInOne.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
-    {{- end }}
+      {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -26,8 +26,6 @@ spec:
         {{- toYaml .Values.schema.podLabels | nindent 8 }}
 {{- end }}
     spec:
-      securityContext:
-        {{- toYaml .Values.schema.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
       {{- with .Values.schema.imagePullSecrets }}
       imagePullSecrets:
@@ -37,8 +35,6 @@ spec:
       - name: {{ include "jaeger.fullname" . }}-cassandra-schema
         image: {{ .Values.schema.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.schema.pullPolicy }}
-        securityContext:
-          {{- toYaml .Values.schema.securityContext | nindent 10 }}
         env:
         {{- if .Values.schema.extraEnv }}
           {{- toYaml .Values.schema.extraEnv | nindent 10 }}
@@ -60,8 +56,15 @@ spec:
           - name: KEYSPACE
             value: {{ .Values.storage.cassandra.keyspace }}
         {{- end }}
+        {{- if .Values.schema.resources }}
         resources:
-          {{- toYaml .Values.schema.resources | nindent 10 }}
+        {{- toYaml .Values.schema.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.schema.podSecurityContext) (.Values.podSecurityContext) }}
+        securityContext:
+        {{- merge .Values.podSecurityContext .Values.schema.podSecurityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.schema.extraConfigmapMounts) (.Values.storage.cassandra.tls.enabled) }}
         volumeMounts:
         {{- range .Values.schema.extraConfigmapMounts }}
           - name: {{ .name }}
@@ -87,7 +90,13 @@ spec:
             subPath: "cqlshrc"
             readOnly: true
         {{- end }}
+        {{- end }}
       restartPolicy: OnFailure
+      {{- if or (.Values.schema.podSecurityContext) (.Values.podSecurityContext) }}
+      securityContext:
+      {{- merge .Values.podSecurityContext .Values.schema.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.schema.extraConfigmapMounts) (.Values.storage.cassandra.tls.enabled) }}
       volumes:
       {{- range .Values.schema.extraConfigmapMounts }}
         - name: {{ .name }}
@@ -98,6 +107,7 @@ spec:
         - name: {{ .Values.storage.cassandra.tls.secretName }}
           secret:
             secretName: {{ .Values.storage.cassandra.tls.secretName }}
+      {{- end }}
       {{- end }}
 {{- end -}}
 {{- end -}}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -35,8 +35,6 @@ spec:
       {{- with .Values.collector.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.collector.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}
       {{- with .Values.collector.imagePullSecrets }}
       imagePullSecrets:
@@ -48,8 +46,6 @@ spec:
       {{- end}}
       containers:
       - name: {{ template "jaeger.collector.name" . }}
-        securityContext:
-          {{- toYaml .Values.collector.securityContext | nindent 10 }}
         image: {{ .Values.collector.image }}:{{- .Values.collector.tag | default (include "jaeger.image.tag" .) }}
         imagePullPolicy: {{ .Values.collector.pullPolicy }}
         args:
@@ -136,8 +132,15 @@ spec:
           httpGet:
             path: /
             port: admin
+        {{- if .Values.collector.resources }}
         resources:
-          {{- toYaml .Values.collector.resources | nindent 10 }}
+        {{- toYaml .Values.collector.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.collector.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.collector.securityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.collector.extraConfigmapMounts) (.Values.collector.extraSecretMounts) (.Values.collector.samplingConfig) (.Values.storage.cassandra.tls.enable) (.Values.storage.elasticsearch.tls.enabled) }}
         volumeMounts:
         {{- range .Values.collector.extraConfigmapMounts }}
           - name: {{ .name }}
@@ -175,8 +178,14 @@ spec:
           - name: strategies
             mountPath: /etc/conf/
         {{- end }}
+        {{- end }}
       dnsPolicy: {{ .Values.collector.dnsPolicy }}
       restartPolicy: Always
+      {{- if or (.Values.collector.podSecurityContext) (.Values.podSecurityContext) }}
+      securityContext:
+      {{- merge .Values.podSecurityContext .Values.collector.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.collector.extraConfigmapMounts) (.Values.collector.extraSecretMounts) (.Values.collector.samplingConfig) (.Values.storage.cassandra.tls.enable) (.Values.storage.elasticsearch.tls.enabled) }}
       volumes:
       {{- range .Values.collector.extraConfigmapMounts }}
         - name: {{ .name }}
@@ -202,6 +211,7 @@ spec:
         - name: {{ .Values.storage.elasticsearch.tls.secretName }}
           secret:
             secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+       {{- end }}
        {{- end }}
     {{- with .Values.collector.nodeSelector }}
       nodeSelector:

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -59,8 +59,15 @@ spec:
               {{- toYaml .Values.esIndexCleaner.extraEnv | nindent 14 }}
             {{- end }}
               {{ include "elasticsearch.env" . | nindent 14 }}
+            {{- if .Values.esIndexCleaner.resources }}
             resources:
-              {{- toYaml .Values.esIndexCleaner.resources | nindent 14 }}
+            {{- toYaml .Values.esIndexCleaner.resources | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esIndexCleaner.securityContext) (.Values.securityContext) }}
+            securityContext:
+            {{- merge .Values.securityContext .Values.esIndexCleaner.securityContext | toYaml | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esIndexCleaner.extraConfigmapMounts) (.Values.esIndexCleaner.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
             volumeMounts:
             {{- range .Values.esIndexCleaner.extraConfigmapMounts }}
               - name: {{ .name }}
@@ -80,6 +87,7 @@ spec:
                 subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
+            {{- end }}
           restartPolicy: OnFailure
         {{- with .Values.esIndexCleaner.nodeSelector }}
           nodeSelector:
@@ -93,6 +101,11 @@ spec:
           tolerations:
             {{- toYaml . | nindent 12 }}
         {{- end }}
+          {{- if or (.Values.esIndexCleaner.podSecurityContext) (.Values.podSecurityContext) }}
+          securityContext:
+          {{- merge .Values.podSecurityContext .Values.esIndexCleaner.podSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if or (.Values.esIndexCleaner.extraConfigmapMounts) (.Values.esIndexCleaner.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
           volumes:
           {{- range .Values.esIndexCleaner.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -108,5 +121,6 @@ spec:
             - name: {{ .Values.storage.elasticsearch.tls.secretName }}
               secret:
                 secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+        {{- end }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -73,8 +73,15 @@ spec:
               {{- if .Values.esLookback.extraEnv }}
                 {{- toYaml .Values.esLookback.extraEnv | nindent 14 }}
               {{- end }}
+            {{- if .Values.esLookback.resources }}
             resources:
-              {{- toYaml .Values.esLookback.resources | nindent 14 }}
+            {{- toYaml .Values.esLookback.resources | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esLoopback.securityContext) (.Values.securityContext) }}
+            securityContext:
+            {{- merge .Values.securityContext .Values.esLoopback.securityContext | toYaml | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esLookback.extraConfigmapMounts) (.Values.esLookback.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
             volumeMounts:
             {{- range .Values.esLookback.extraConfigmapMounts }}
               - name: {{ .name }}
@@ -94,6 +101,12 @@ spec:
                 subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
+            {{- end }}
+          {{- if or (.Values.esLoopback.podSecurityContext) (.Values.podSecurityContext) }}
+          securityContext:
+          {{- merge .Values.podSecurityContext .Values.esLoopback.podSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if or (.Values.esLookback.extraConfigmapMounts) (.Values.esLookback.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
           volumes:
           {{- range .Values.esLookback.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -109,5 +122,6 @@ spec:
             - name: {{ .Values.storage.elasticsearch.tls.secretName }}
               secret:
                 secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+        {{- end }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -73,8 +73,15 @@ spec:
               {{- if .Values.esRollover.extraEnv }}
                 {{- toYaml .Values.esRollover.extraEnv | nindent 14 }}
               {{- end }}
+            {{- if .Values.esRollover.resources }}
             resources:
-              {{- toYaml .Values.esRollover.resources | nindent 14 }}
+            {{- toYaml .Values.esRollover.resources | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esRollover.securityContext) (.Values.securityContext) }}
+            securityContext:
+            {{- merge .Values.securityContext .Values.esRollover.securityContext | toYaml | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.esRollover.extraConfigmapMounts) (.Values.esRollover.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
             volumeMounts:
             {{- range .Values.esRollover.extraConfigmapMounts }}
               - name: {{ .name }}
@@ -94,6 +101,12 @@ spec:
                 subPath: {{ .Values.storage.elasticsearch.tls.subPath }}
                 readOnly: true
             {{- end }}
+            {{- end }}
+          {{- if or (.Values.esRollover.podSecurityContext) (.Values.podSecurityContext) }}
+          securityContext:
+          {{- merge .Values.podSecurityContext .Values.esRollover.podSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
+          {{- if or (.Values.esRollover.extraConfigmapMounts) (.Values.esRollover.extraSecretMounts) (.Values.storage.elasticsearch.tls.enabled) }}
           volumes:
           {{- range .Values.esRollover.extraConfigmapMounts }}
             - name: {{ .name }}
@@ -109,5 +122,6 @@ spec:
             - name: {{ .Values.storage.elasticsearch.tls.secretName }}
               secret:
                 secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+        {{- end }}
         {{- end }}
 {{- end -}}

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -18,8 +18,10 @@ spec:
         {{- include "jaeger.selectorLabels" . | nindent 8 }}
         app.kubernetes.io/component: hotrod
     spec:
+      {{- if or (.Values.hotrod.podSecurityContext) (.Values.podSecurityContext) }}
       securityContext:
-        {{- toYaml .Values.hotrod.podSecurityContext | nindent 8 }}
+      {{- merge .Values.podSecurityContext .Values.hotrod.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
       serviceAccountName: {{ template "jaeger.hotrod.serviceAccountName" . }}
       {{- with .Values.hotrod.image.pullSecrets }}
       imagePullSecrets:
@@ -27,8 +29,6 @@ spec:
       {{- end }}
       containers:
         - name: {{ include "jaeger.fullname" . }}-hotrod
-          securityContext:
-            {{- toYaml .Values.hotrod.securityContext | nindent 12 }}
           image: {{ .Values.hotrod.image.repository }}:{{- include "jaeger.image.tag" . }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
           args:
@@ -58,6 +58,10 @@ spec:
               port: http
           resources:
             {{- toYaml .Values.hotrod.resources | nindent 12 }}
+          {{- if or (.Values.hotrod.securityContext) (.Values.securityContext) }}
+          securityContext:
+          {{- merge .Values.securityContext .Values.hotrod.securityContext | toYaml | nindent 12 }}
+          {{- end }}
     {{- with .Values.hotrod.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -32,8 +32,10 @@ spec:
 {{- end }}
     spec:
       serviceAccountName: {{ include "jaeger.ingester.serviceAccountName" . }}
+      {{- if or (.Values.ingester.podSecurityContext) (.Values.podSecurityContext) }}
       securityContext:
-        {{- toYaml .Values.ingester.podSecurityContext | nindent 8 }}
+      {{- merge .Values.podSecurityContext .Values.ingester.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
       {{- with .Values.ingester.imagePullSecrets }}
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
@@ -52,8 +54,6 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-ingester
-        securityContext:
-          {{- toYaml .Values.ingester.securityContext | nindent 10 }}
         image: {{ .Values.ingester.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.ingester.pullPolicy }}
         args:
@@ -95,6 +95,10 @@ spec:
             port: admin
         resources:
           {{- toYaml .Values.ingester.resources | nindent 10 }}
+        {{- if or (.Values.ingester.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.ingester.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         volumeMounts:
         {{- range .Values.ingester.extraConfigmapMounts }}
           - name: {{ .name }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -37,8 +37,6 @@ spec:
       {{- with .Values.query.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
-      securityContext:
-        {{- toYaml .Values.query.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
       {{- with .Values.query.imagePullSecrets }}
       imagePullSecrets:
@@ -46,8 +44,6 @@ spec:
       {{- end }}
       containers:
       - name: {{ template "jaeger.query.name" . }}
-        securityContext:
-          {{- toYaml .Values.query.securityContext | nindent 10 }}
         image: {{ .Values.query.image }}:{{- .Values.query.tag | default (include "jaeger.image.tag" .) }}
         imagePullPolicy: {{ .Values.query.pullPolicy }}
         args:
@@ -83,8 +79,15 @@ spec:
         - name: admin
           containerPort: 16687
           protocol: TCP
+        {{- if .Values.query.resources }}
         resources:
-          {{- toYaml .Values.query.resources | nindent 10 }}
+        {{- toYaml .Values.query.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.query.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.query.securityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.query.extraConfigmapMounts) (.Values.query.extraSecretMounts) (.Values.query.config) (.Values.storage.cassandra.tls.enabled) (.Values.storage.elasticsearch.tls.enabled) }}
         volumeMounts:
         {{- range .Values.query.extraSecretMounts }}
           - name: {{ .name }}
@@ -122,6 +125,7 @@ spec:
           - name: ui-configuration
             mountPath: /etc/conf/
         {{- end }}
+        {{- end }}
         livenessProbe:
           httpGet:
             path: /
@@ -134,14 +138,17 @@ spec:
       - name: {{ template "jaeger.agent.name" . }}-oauth2-sidecar
         image: {{ .Values.query.oAuthSidecar.image }}
         imagePullPolicy: {{ .Values.query.oAuthSidecar.pullPolicy }}
+        {{- if .Values.query.oAuthSidecar.args }}
         args:
         {{- range .Values.query.oAuthSidecar.args }}
           - {{ . }}
+        {{- end }}
         {{- end }}
         {{- if .Values.query.oAuthSidecar.extraEnv }}
         env:
           {{- toYaml .Values.query.oAuthSidecar.extraEnv | nindent 10 }}
         {{- end }}
+        {{- if or (.Values.query.oAuthSidecar.extraConfigmapMounts) (.Values.query.oAuthSidecar.extraSecretMounts) (.Values.query.oAuthSidecar.config)}}
         volumeMounts:
         {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}
           - name: {{ .name }}
@@ -159,11 +166,18 @@ spec:
           - name: jaeger-oauth-configuration
             mountPath: /etc/oauth2-proxy
         {{- end }}
+        {{- end }}
         ports:
           - containerPort: {{ .Values.query.oAuthSidecar.containerPort }}
             name: oauth-proxy
+        {{- if .Values.query.oAuthSidecar.resources }}
         resources:
-          {{- toYaml .Values.query.oAuthSidecar.resources | nindent 10 }}
+        {{- toYaml .Values.query.oAuthSidecar.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.query.oAuthSidecar.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.query.oAuthSidecar.securityContext | toYaml | nindent 10 }}
+        {{- end }}
         {{- if .Values.query.oAuthSidecar.livenessProbe }}
         livenessProbe:
           {{- toYaml .Values.query.oAuthSidecar.livenessProbe | nindent 10 }}
@@ -175,10 +189,9 @@ spec:
 {{- end }}
 {{- if .Values.query.agentSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-sidecar
-        securityContext:
-          {{- toYaml .Values.query.securityContext | nindent 10 }}
         image: {{ .Values.agent.image }}:{{- include "jaeger.image.tag" . }}
         imagePullPolicy: {{ .Values.agent.pullPolicy }}
+        {{- if .Values.agent.cmdlineParams }}
         args:
           {{- range $key, $value := .Values.agent.cmdlineParams }}
           {{- if $value }}
@@ -187,8 +200,9 @@ spec:
           - --{{ $key }}
           {{- end }}
           {{- end }}
-        env:
+        {{- end }}
         {{- if not (hasKey .Values.agent.cmdlineParams "reporter.grpc.host-port") }}
+        env:
         - name: REPORTER_GRPC_HOST_PORT
           value: {{ include "jaeger.collector.name" . }}:{{ .Values.collector.service.grpc.port }}
         {{- end }}
@@ -196,8 +210,15 @@ spec:
         - name: admin
           containerPort: 14271
           protocol: TCP
+        {{- if .Values.query.agentSidecar.resources }}
         resources:
-          {{- toYaml .Values.query.agentSidecar.resources | nindent 10 }}
+        {{- toYaml .Values.query.agentSidecar.resources | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.query.agentSidecar.securityContext) (.Values.securityContext) }}
+        securityContext:
+        {{- merge .Values.securityContext .Values.query.agentSidecar.securityContext | toYaml | nindent 10 }}
+        {{- end }}
+        {{- if or (.Values.agent.extraConfigmapMounts) (.Values.agent.extraSecretMounts) }}
         volumeMounts:
         {{- range .Values.agent.extraConfigmapMounts }}
           - name: {{ .name }}
@@ -210,6 +231,7 @@ spec:
             mountPath: {{ .mountPath }}
             subPath: {{ .subPath }}
             readOnly: {{ .readOnly }}
+        {{- end }}
         {{- end }}
         livenessProbe:
           httpGet:
@@ -225,6 +247,11 @@ spec:
       {{- end }}
       dnsPolicy: {{ .Values.query.dnsPolicy }}
       restartPolicy: Always
+      {{- if or (.Values.query.podSecurityContext) (.Values.podSecurityContext) }}
+      securityContext:
+      {{- merge .Values.podSecurityContext .Values.query.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
+      {{- if or (.Values.query.extraConfigmapMounts) (.Values.query.extraSecretMounts) (.Values.query.config) (.Values.storage.cassandra.tls.enabled) (.Values.storage.elasticsearch.tls.enabled) }}
       volumes:
       {{- range .Values.query.extraConfigmapMounts }}
         - name: {{ .name }}
@@ -250,6 +277,7 @@ spec:
         - name: {{ .Values.storage.elasticsearch.tls.secretName }}
           secret:
             secretName: {{ .Values.storage.elasticsearch.tls.secretName }}
+       {{- end }}
        {{- end }}
 {{- if .Values.query.oAuthSidecar.enabled }}
       {{- range .Values.query.oAuthSidecar.extraConfigmapMounts }}

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -64,8 +64,14 @@ spec:
               - name: ES_NODES_WAN_ONLY
                 value: {{ .Values.storage.elasticsearch.nodesWanOnly | quote }}
             {{- end }}
+            {{- if .Values.spark.resources }}
             resources:
-              {{- toYaml .Values.spark.resources | nindent 14 }}
+            {{- toYaml .Values.spark.resources | nindent 14 }}
+            {{- end }}
+            {{- if or (.Values.spark.securityContext) (.Values.securityContext) }}
+            securityContext:
+            {{- merge .Values.securityContext .Values.spark.securityContext | toYaml | nindent 14 }}
+            {{- end }}
             volumeMounts:
             {{- range .Values.spark.extraConfigmapMounts }}
               - name: {{ .name }}
@@ -80,6 +86,10 @@ spec:
                 readOnly: {{ .readOnly }}
             {{- end }}
           restartPolicy: OnFailure
+          {{- if or (.Values.spark.podSecurityContext) (.Values.podSecurityContext) }}
+          securityContext:
+          {{- merge .Values.podSecurityContext .Values.spark.podSecurityContext | toYaml | nindent 12 }}
+          {{- end }}
           volumes:
           {{- range .Values.spark.extraConfigmapMounts }}
             - name: {{ .name }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -2,6 +2,23 @@
 # This is a YAML-formatted file.
 # Jaeger values are grouped by component. Cassandra values override subchart values
 
+# Set securityContext for pod or container global and/or define for each service
+podSecurityContext: {}
+# podSecurityContext:
+#   fsGroup: 1000
+#   supplementalGroups:
+#     - 1000
+securityContext: {}
+# securityContext:
+#   allowPrivilegeEscalation: false
+#   capabilities:
+#     drop:
+#     - ALL
+#   privileged: false
+#   readOnlyRootFilesystem: true
+#   runAsUser: 1000
+#   runAsGroup: 1000
+
 provisionDataStore:
   cassandra: true
   elasticsearch: false
@@ -17,7 +34,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 allInOne:
-  enabled: false
+  enabled: true
   replicas: 1
   image: jaegertracing/all-in-one
   imagePullSecrets: []
@@ -77,6 +94,8 @@ allInOne:
   #     cpu: 256m
   #     memory: 128Mi
   nodeSelector: {}
+  podSecurityContext: {}
+  securityContext: {}
 
 storage:
   # allowed values (cassandra, elasticsearch)
@@ -194,8 +213,7 @@ schema:
   image: jaegertracing/jaeger-cassandra-schema
   imagePullSecrets: []
   pullPolicy: IfNotPresent
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
@@ -213,8 +231,7 @@ schema:
   podSecurityContext: {}
   ## Deadline for cassandra schema creation job
   activeDeadlineSeconds: 300
-  extraEnv:
-    []
+  extraEnv: []
     # - name: MODE
     #   value: prod
     # - name: TRACE_TTL
@@ -249,8 +266,7 @@ ingester:
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
@@ -284,8 +300,6 @@ ingester:
     metricRelabelings: []
 
 agent:
-  podSecurityContext: {}
-  securityContext: {}
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-agent
@@ -314,14 +328,15 @@ agent:
     binaryPort: 6832
     # samplingPort: (HTTP) serve configs, sampling strategies
     samplingPort: 5778
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -363,8 +378,6 @@ agent:
     metricRelabelings: []
 
 collector:
-  podSecurityContext: {}
-  securityContext: {}
   enabled: true
   annotations: {}
   image: jaegertracing/jaeger-collector
@@ -442,14 +455,15 @@ collector:
     #   hosts:
     #     - chart-example.local
     pathType:
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 1
     #   memory: 1Gi
     # requests:
     #   cpu: 500m
     #   memory: 512Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -475,6 +489,7 @@ collector:
   #   subPath: ""
   #   configMap: jaeger-config
   #   readOnly: true
+  samplingConfig: {}
   # samplingConfig: |-
   #   {
   #     "service_strategies": [
@@ -532,14 +547,15 @@ query:
   basePath: /
   oAuthSidecar:
     enabled: false
-    resources:
-      {}
+    resources: {}
       # limits:
       #   cpu: 500m
       #   memory: 512Mi
       # requests:
       #   cpu: 256m
       #   memory: 128Mi
+    podSecurityContext: {}
+    securityContext: {}
     image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
     pullPolicy: IfNotPresent
     containerPort: 4180
@@ -559,17 +575,27 @@ query:
   #   oidc_groups_claim = "groups"
   #   user_id_claim = "preferred_username"
   #   skip_provider_button = "true"
+  resources: {}
+  # resources:
+  #   limits:
+  #     cpu: 500m
+  #     memory: 512Mi
+  #   requests:
+  #     cpu: 256m
+  #     memory: 128Mi
   podSecurityContext: {}
   securityContext: {}
   agentSidecar:
     enabled: true
-  #    resources:
-  #      limits:
-  #        cpu: 500m
-  #        memory: 512Mi
-  #      requests:
-  #        cpu: 256m
-  #        memory: 128Mi
+    resources: {}
+      # limits:
+      #   cpu: 500m
+      #   memory: 512Mi
+      # requests:
+      #   cpu: 256m
+      #   memory: 128Mi
+    podSecurityContext: {}
+    securityContext: {}
   annotations: {}
   image: jaegertracing/jaeger-query
   # tag: 1.22
@@ -613,14 +639,6 @@ query:
     pathType:
     health:
       exposed: false
-  resources:
-    {}
-    # limits:
-    #   cpu: 500m
-    #   memory: 512Mi
-    # requests:
-    #    cpu: 256m
-    #    memory: 128Mi
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -680,7 +698,7 @@ query:
     #   customRules: []
 
 spark:
-  enabled: false
+  enabled: true
   annotations: {}
   image: jaegertracing/spark-dependencies
   imagePullSecrets: []
@@ -692,14 +710,15 @@ spark:
   successfulJobsHistoryLimit: 5
   failedJobsHistoryLimit: 5
   concurrencyPolicy: Forbid
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -735,14 +754,15 @@ esIndexCleaner:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   numberOfDays: 7
   serviceAccount:
     create: true
@@ -778,14 +798,15 @@ esRollover:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -831,14 +852,15 @@ esLookback:
   successfulJobsHistoryLimit: 3
   failedJobsHistoryLimit: 3
   concurrencyPolicy: Forbid
-  resources:
-    {}
+  resources: {}
     # limits:
     #   cpu: 500m
     #   memory: 512Mi
     # requests:
     #   cpu: 256m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account
@@ -858,8 +880,6 @@ esLookback:
 
 hotrod:
   enabled: false
-  podSecurityContext: {}
-  securityContext: {}
   replicaCount: 1
   # set the primary command(s) for the hotrod application
   args:
@@ -901,8 +921,7 @@ hotrod:
       #   hosts:
       #     - chart-example.local
     pathType:
-  resources:
-    {}
+  resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little
     # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -913,6 +932,8 @@ hotrod:
     # requests:
     #   cpu: 100m
     #   memory: 128Mi
+  podSecurityContext: {}
+  securityContext: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -34,7 +34,7 @@ nameOverride: ""
 fullnameOverride: ""
 
 allInOne:
-  enabled: true
+  enabled: false
   replicas: 1
   image: jaegertracing/all-in-one
   imagePullSecrets: []
@@ -698,7 +698,7 @@ query:
     #   customRules: []
 
 spark:
-  enabled: true
+  enabled: false
   annotations: {}
   image: jaegertracing/spark-dependencies
   imagePullSecrets: []

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -639,7 +639,6 @@ query:
     pathType:
     health:
       exposed: false
-  resources: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -639,6 +639,7 @@ query:
     pathType:
     health:
       exposed: false
+  resources: {}
   serviceAccount:
     create: true
     # Explicitly mounts the API credentials for the Service Account


### PR DESCRIPTION
#### What this PR does

At least and especially for the all-in-one installation securityContext was missing  which brings a bad experienance if you start with Jaeger. This PR

- add missing podSecurityContext/securityContext all-in-one
- add a global defintion for podSecurityContext/securityContext
- re-define value for each kind of workload
- conditions for other optional resource


#### Which issue this PR fixes

- fixes #41 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
