### PR TITLE
[jaeger-operator] Bump image in values to 1.52.0

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.50.0
+version: 2.50.1
 appVersion: 1.52.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.49.0
+  tag: 1.52.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does
According to the chart appversion https://github.com/jaegertracing/helm-charts/blob/ce83c06bd256af413c53ce1110d38d96a31156c0/charts/jaeger-operator/Chart.yaml#L5

and readme

https://github.com/jaegertracing/helm-charts/blob/ce83c06bd256af413c53ce1110d38d96a31156c0/charts/jaeger-operator/README.md?plain=1#L62

it looks like the jaeger-operator image should be `1.52.0`, however it hasn't been updated in the values file.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #535 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
