### PR TITLE
[jaeger] Adding optional initContainers for jaeger query and ingester deployments

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.51.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 0.73.1
+version: 0.73.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -50,6 +50,10 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.ingester.initContainers }}
+      initContainers:
+      {{- toYaml .Values.ingester.initContainers | nindent 8 }}
+      {{- end}}
       containers:
       - name: {{ include "jaeger.fullname" . }}-ingester
         securityContext:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -44,6 +44,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.query.initContainers }}
+      initContainers:
+      {{- toYaml .Values.query.initContainers | nindent 8 }}
+      {{- end}} 
       containers:
       - name: {{ template "jaeger.query.name" . }}
         securityContext:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -276,6 +276,7 @@ ingester:
   extraConfigmapMounts: []
   extraEnv: []
   envFrom: []
+  initContainers: []
 
   serviceMonitor:
     enabled: false
@@ -533,6 +534,7 @@ collector:
 query:
   enabled: true
   basePath: /
+  initContainers: []
   oAuthSidecar:
     enabled: false
     resources:


### PR DESCRIPTION
#### What this PR does
Adds optional initContainers for jaeger query and ingester deployments

#### Which issue this PR fixes
- fixes #512

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
~- [] README.md has been updated to match version/contain new values~
