### PR TITLE
[jaeger] make Deployment depend on oauth2 config, if enabled

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 1.0.0
+version: 1.0.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -23,6 +23,9 @@ spec:
       {{- if .Values.query.config }}
         checksum/ui-config: {{ include (print $.Template.BasePath "/query-configmap.yaml") . | sha256sum }}
       {{- end }}
+      {{- if and .Values.query.oAuthSidecar.enabled .Values.query.oAuthSidecar.config }}
+        checksum/oauth2-config: {{ sha256sum .Values.query.oAuthSidecar.config }}
+      {{- end }}
       {{- if .Values.query.podAnnotations }}
         {{- toYaml .Values.query.podAnnotations | nindent 8 }}
       {{- end }}


### PR DESCRIPTION
#### What this PR does

Without this, changes to the oauth2-proxy configuration don't affect any metadata in the Deployment, meaning pods must be deleted manually after a configuration change.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
