### PR TITLE
[jaeger] Allow overriding image registry at the global level

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 1.0.2
+version: 2.0.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -352,7 +352,10 @@ query:
   oAuthSidecar:
     enabled: true
     resources: {}
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.3.0
+    image:
+      registry: quay.io
+      repository: oauth2-proxy/oauth2-proxy
+      tag: v7.3.0
     pullPolicy: IfNotPresent
     containerPort: 4180
     args:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -32,13 +32,6 @@ Create chart name and version as used by the chart label.
 {{- end -}}
 
 {{/*
-Create image tag value which defaults to .Chart.AppVersion.
-*/}}
-{{- define "jaeger.image.tag" -}}
-{{- .Values.tag | default .Chart.AppVersion }}
-{{- end -}}
-
-{{/*
 Common labels
 */}}
 {{- define "jaeger.labels" -}}
@@ -523,3 +516,175 @@ spec:
   {{- include "common.tplvalues.render" (dict "value" .ComponentValues.networkPolicy.egressRules.customRules "context" $) | nindent 2 }}
   {{- end }}
 {{- end -}}
+
+{{/*
+Create image name value
+If not tag is provided, it defaults to .Chart.AppVersion.
+( dict "imageRoot" .Values.path.to.image "context" $ )
+*/}}
+{{- define "renderImage" -}}
+{{- $image := merge .imageRoot (dict "tag" .context.Chart.AppVersion) -}}
+{{- include "common.images.image" (dict "imageRoot" $image "global" .context.Values.Global) -}}
+{{- end -}}
+
+{{/*
+Create image name for all in one image
+*/}}
+{{- define "allInOne.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.allInOne.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for all in one image
+*/}}
+{{- define "allInOne.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.allInOne.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for schema image
+*/}}
+{{- define "schema.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.schema.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for schema image
+*/}}
+{{- define "schema.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.schema.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for ingester image
+*/}}
+{{- define "ingester.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.ingester.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for ingester image
+*/}}
+{{- define "ingester.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.ingester.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for agent image
+*/}}
+{{- define "agent.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.agent.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for agent image
+*/}}
+{{- define "agent.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.agent.image) "context" $) -}}
+{{- end }}
+
+
+{{/*
+Create image name for collector image
+*/}}
+{{- define "collector.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.collector.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for collector image
+*/}}
+{{- define "collector.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.collector.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for query image
+*/}}
+{{- define "query.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.query.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for query image
+*/}}
+{{- define "query.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.query.image .Values.query.oAuthSidecar.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for oAuthSidecar image
+*/}}
+{{- define "oAuthSidecar.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.query.oAuthSidecar.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create image name for spark image
+*/}}
+{{- define "spark.image" -}}
+{{- include "common.images.image" (dict "imageRoot" .Values.spark.image "global" .Values.global) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for spark image
+*/}}
+{{- define "spark.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.spark.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for esIndexCleaner image
+*/}}
+{{- define "esIndexCleaner.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.esIndexCleaner.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for esIndexCleaner image
+*/}}
+{{- define "esIndexCleaner.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.esIndexCleaner.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for esRollover image
+*/}}
+{{- define "esRollover.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.esRollover.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for esRollover image
+*/}}
+{{- define "esRollover.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.esRollover.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for esLookback image
+*/}}
+{{- define "esLookback.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.esLookback.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for esLookback image
+*/}}
+{{- define "esLookback.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.esLookback.image) "context" $) -}}
+{{- end }}
+
+{{/*
+Create image name for hotrod image
+*/}}
+{{- define "hotrod.image" -}}
+{{- include "renderImage" ( dict "imageRoot" .Values.hotrod.image "context" $ ) -}}
+{{- end -}}
+
+{{/*
+Create pull secrets for hotrod image
+*/}}
+{{- define "hotrod.imagePullSecrets" -}}
+{{- include "common.images.renderPullSecrets" (dict "images" (list .Values.hotrod.image) "context" $) -}}
+{{- end }}

--- a/charts/jaeger/templates/agent-ds.yaml
+++ b/charts/jaeger/templates/agent-ds.yaml
@@ -42,10 +42,7 @@ spec:
       priorityClassName: {{ . }}
       {{- end }}
       serviceAccountName: {{ template "jaeger.agent.serviceAccountName" . }}
-      {{- with .Values.agent.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "agent.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.agent.initContainers }}
       initContainers:
         {{- toYaml .Values.agent.initContainers | nindent 8 }}
@@ -54,8 +51,8 @@ spec:
       - name: {{ template "jaeger.agent.name" . }}
         securityContext:
           {{- toYaml .Values.agent.securityContext | nindent 10 }}
-        image: {{ .Values.agent.image }}:{{- .Values.agent.tag | default (include "jaeger.image.tag" .) }}
-        imagePullPolicy: {{ .Values.agent.pullPolicy }}
+        image: {{ include "agent.image" . }}
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         args:
           {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.agent.cmdlineParams ) | nindent 10  }}
         env:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -30,10 +30,7 @@ spec:
         prometheus.io/port: "14269"
         prometheus.io/scrape: "true"
     spec:
-      {{- with .Values.allInOne.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}    
+      {{- include "allInOne.imagePullSecrets" . | nindent 6 }}  
       containers:
         - env:
           {{- if .Values.allInOne.extraEnv }}
@@ -54,8 +51,8 @@ spec:
         {{- with .Values.allInOne.envFrom }}
           envFrom: {{- toYaml . | nindent 12 }}
         {{- end }}
-          image: {{ .Values.allInOne.image }}:{{- .Values.allInOne.tag | default (include "jaeger.image.tag" .) }}
-          imagePullPolicy: {{ .Values.allInOne.pullPolicy }}
+          image: {{ include "allInOne.image" . }}
+          imagePullPolicy: {{ .Values.allInOne.image.pullPolicy }}
           name: jaeger
           args:
             {{- range $arg := .Values.allInOne.args }}

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -29,14 +29,11 @@ spec:
       securityContext:
         {{- toYaml .Values.schema.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.cassandraSchema.serviceAccountName" . }}
-      {{- with .Values.schema.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "schema.imagePullSecrets" . | nindent 6 }}
       containers:
       - name: {{ include "jaeger.fullname" . }}-cassandra-schema
-        image: {{ .Values.schema.image }}:{{- include "jaeger.image.tag" . }}
-        imagePullPolicy: {{ .Values.schema.pullPolicy }}
+        image: {{ include "schema.image" . }}
+        imagePullPolicy: {{ .Values.schema.image.pullPolicy }}
         securityContext:
           {{- toYaml .Values.schema.securityContext | nindent 10 }}
         env:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -38,10 +38,7 @@ spec:
       securityContext:
         {{- toYaml .Values.collector.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.collector.serviceAccountName" . }}
-      {{- with .Values.collector.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "collector.imagePullSecrets" . | nindent 6 }} 
       {{- if .Values.collector.initContainers }}
       initContainers:
         {{- toYaml .Values.collector.initContainers | nindent 8 }}
@@ -50,8 +47,8 @@ spec:
       - name: {{ template "jaeger.collector.name" . }}
         securityContext:
           {{- toYaml .Values.collector.securityContext | nindent 10 }}
-        image: {{ .Values.collector.image }}:{{- .Values.collector.tag | default (include "jaeger.image.tag" .) }}
-        imagePullPolicy: {{ .Values.collector.pullPolicy }}
+        image: {{ include "collector.image" . }}
+        imagePullPolicy: {{ .Values.collector.image.pullPolicy }}
         args:
           {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.collector.cmdlineParams ) | nindent 10  }}
           {{- if not .Values.ingester.enabled -}}

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -38,18 +38,15 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esIndexCleaner.serviceAccountName" . }}
-          {{- with .Values.esIndexCleaner.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "esIndexCleaner.imagePullSecrets" . | nindent 12 }}
           securityContext:
             {{- toYaml .Values.esIndexCleaner.podSecurityContext | nindent 12 }}
           containers:
           - name: {{ include "jaeger.fullname" . }}-es-index-cleaner
             securityContext:
               {{- toYaml .Values.esIndexCleaner.securityContext | nindent 14 }}
-            image: {{ .Values.esIndexCleaner.image }}:{{- .Values.esIndexCleaner.tag | default (include "jaeger.image.tag" .) }}
-            imagePullPolicy: {{ .Values.esIndexCleaner.pullPolicy }}
+            image: {{ include "esIndexCleaner.image" . }}
+            imagePullPolicy: {{ .Values.esIndexCleaner.image.pullPolicy }}
             args:
               - {{ .Values.esIndexCleaner.numberOfDays | quote }}
               - {{ include "elasticsearch.client.url" . }}

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -38,10 +38,7 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esLookback.serviceAccountName" . }}
-          {{- with .Values.esLookback.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "esLookback.imagePullSecrets" . | nindent 12 }}  
           securityContext:
             {{- toYaml .Values.esLookback.podSecurityContext | nindent 12 }}
           restartPolicy: OnFailure
@@ -62,8 +59,8 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-es-lookback
             securityContext:
               {{- toYaml .Values.esLookback.securityContext | nindent 14 }}
-            image: "{{ .Values.esLookback.image }}:{{- include "jaeger.image.tag" . }}"
-            imagePullPolicy: {{ .Values.esLookback.pullPolicy }}
+            image: {{ include "esLookback.image" . }}
+            imagePullPolicy: {{ .Values.esLookback.image.pullPolicy }}
             args:
               - lookback
               - {{ include "elasticsearch.client.url" . }}

--- a/charts/jaeger/templates/es-rollover-cronjob.yaml
+++ b/charts/jaeger/templates/es-rollover-cronjob.yaml
@@ -38,10 +38,7 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esRollover.serviceAccountName" . }}
-          {{- with .Values.esRollover.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "esRollover.imagePullSecrets" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.esRollover.podSecurityContext | nindent 12 }}
           restartPolicy: OnFailure
@@ -62,8 +59,8 @@ spec:
           - name: {{ include "jaeger.fullname" . }}-es-rollover
             securityContext:
               {{- toYaml .Values.esRollover.securityContext | nindent 14 }}
-            image: "{{ .Values.esRollover.image }}:{{- include "jaeger.image.tag" . }}"
-            imagePullPolicy: {{ .Values.esRollover.pullPolicy }}
+            image: {{ include "esRollover.image" . }}
+            imagePullPolicy: {{ .Values.esRollover.image.pullPolicy }}
             args:
               - rollover
               - {{ include "elasticsearch.client.url" . }}

--- a/charts/jaeger/templates/es-rollover-hook.yml
+++ b/charts/jaeger/templates/es-rollover-hook.yml
@@ -33,9 +33,7 @@ spec:
         {{- end }}
     spec:
       serviceAccountName: {{ template "jaeger.esRollover.serviceAccountName" . }}
-      {{- with .Values.esRollover.imagePullSecrets }}
-      imagePullSecrets: {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "esRollover.imagePullSecrets" . | nindent 6 }}
       securityContext: {{- toYaml .Values.esRollover.podSecurityContext | nindent 8 }}
       restartPolicy: OnFailure
       {{- with .Values.esRollover.nodeSelector }}
@@ -51,8 +49,8 @@ spec:
       containers:
         - name: {{ include "jaeger.fullname" . }}-es-rollover-init
           securityContext: {{- toYaml .Values.esRollover.securityContext | nindent 12 }}
-          image: "{{ .Values.esRollover.image }}:{{ .Values.esRollover.tag }}"
-          imagePullPolicy: {{ .Values.esRollover.pullPolicy }}
+          image: {{ include "esRollover.image" . }}
+          imagePullPolicy: {{ .Values.esRollover.image.pullPolicy }}
           args:
             - init
             - {{ include "elasticsearch.client.url" . }}

--- a/charts/jaeger/templates/hotrod-deploy.yaml
+++ b/charts/jaeger/templates/hotrod-deploy.yaml
@@ -21,15 +21,12 @@ spec:
       securityContext:
         {{- toYaml .Values.hotrod.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.hotrod.serviceAccountName" . }}
-      {{- with .Values.hotrod.image.pullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "hotrod.imagePullSecrets" . | nindent 6 }}  
       containers:
         - name: {{ include "jaeger.fullname" . }}-hotrod
           securityContext:
             {{- toYaml .Values.hotrod.securityContext | nindent 12 }}
-          image: {{ .Values.hotrod.image.repository }}:{{- include "jaeger.image.tag" . }}
+          image: {{ include "hotrod.image" . }}
           imagePullPolicy: {{ .Values.hotrod.image.pullPolicy }}
           args:
             {{- toYaml .Values.hotrod.args | nindent 12 }}

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -34,10 +34,7 @@ spec:
       serviceAccountName: {{ include "jaeger.ingester.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.ingester.podSecurityContext | nindent 8 }}
-      {{- with .Values.ingester.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "ingester.imagePullSecrets" . | nindent 6 }}
       {{- with .Values.ingester.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
@@ -58,8 +55,8 @@ spec:
       - name: {{ include "jaeger.fullname" . }}-ingester
         securityContext:
           {{- toYaml .Values.ingester.securityContext | nindent 10 }}
-        image: {{ .Values.ingester.image }}:{{- include "jaeger.image.tag" . }}
-        imagePullPolicy: {{ .Values.ingester.pullPolicy }}
+        image: {{ include "ingester.image" . }}
+        imagePullPolicy: {{ .Values.ingester.image.pullPolicy }}
         args:
           {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.ingester.cmdlineParams ) | nindent 10  }}
           {{- include "storage.cmdArgs" . | nindent 10 }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -43,10 +43,7 @@ spec:
       securityContext:
         {{- toYaml .Values.query.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
-      {{- with .Values.query.imagePullSecrets }}
-      imagePullSecrets:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "query.imagePullSecrets" . | nindent 6 }}
       {{- if .Values.query.initContainers }}
       initContainers:
       {{- toYaml .Values.query.initContainers | nindent 8 }}
@@ -55,8 +52,8 @@ spec:
       - name: {{ template "jaeger.query.name" . }}
         securityContext:
           {{- toYaml .Values.query.securityContext | nindent 10 }}
-        image: {{ .Values.query.image }}:{{- .Values.query.tag | default (include "jaeger.image.tag" .) }}
-        imagePullPolicy: {{ .Values.query.pullPolicy }}
+        image: {{ include "query.image" . }}
+        imagePullPolicy: {{ .Values.query.image.pullPolicy }}
         args:
           {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.query.cmdlineParams ) | nindent 10  }}
           {{- include "storage.cmdArgs" . | nindent 10 }}
@@ -139,8 +136,8 @@ spec:
             port: admin
 {{- if .Values.query.oAuthSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-oauth2-sidecar
-        image: {{ .Values.query.oAuthSidecar.image }}
-        imagePullPolicy: {{ .Values.query.oAuthSidecar.pullPolicy }}
+        image: {{ include "oAuthSidecar.image" . }}
+        imagePullPolicy: {{ .Values.query.oAuthSidecar.image.pullPolicy }}
         args:
         {{- range .Values.query.oAuthSidecar.args }}
           - {{ . }}
@@ -184,8 +181,8 @@ spec:
       - name: {{ template "jaeger.agent.name" . }}-sidecar
         securityContext:
           {{- toYaml .Values.query.securityContext | nindent 10 }}
-        image: {{ .Values.agent.image }}:{{- include "jaeger.image.tag" . }}
-        imagePullPolicy: {{ .Values.agent.pullPolicy }}
+        image: {{ include "agent.image" . }}
+        imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         args:
           {{- range $key, $value := .Values.agent.cmdlineParams }}
           {{- if $value }}

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -37,14 +37,11 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.spark.serviceAccountName" . }}
-          {{- with .Values.spark.imagePullSecrets }}
-          imagePullSecrets:
-            {{- toYaml . | nindent 12 }}
-          {{- end }}
+          {{- include "spark.imagePullSecrets" . | nindent 12 }}  
           containers:
           - name: {{ include "jaeger.fullname" . }}-spark
-            image: {{ .Values.spark.image }}:{{ .Values.spark.tag }}
-            imagePullPolicy: {{ .Values.spark.pullPolicy }}
+            image: {{ include "spark.image" . }}
+            imagePullPolicy: {{ .Values.spark.image.pullPolicy }}
             args:
               {{ include "extra.cmdArgs" ( dict "cmdlineParams" .Values.spark.cmdlineParams ) | nindent 14  }}
             env:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -2,6 +2,9 @@
 # This is a YAML-formatted file.
 # Jaeger values are grouped by component. Cassandra values override subchart values
 
+global:
+  imageRegistry:
+
 provisionDataStore:
   cassandra: true
   elasticsearch: false
@@ -19,9 +22,13 @@ fullnameOverride: ""
 allInOne:
   enabled: false
   replicas: 1
-  image: jaegertracing/all-in-one
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/all-in-one
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   extraEnv: []
   extraSecretMounts:
     []
@@ -208,9 +215,13 @@ kafka:
 # use by Jaeger
 schema:
   annotations: {}
-  image: jaegertracing/jaeger-cassandra-schema
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-cassandra-schema
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   resources:
     {}
     # limits:
@@ -248,9 +259,13 @@ ingester:
   podSecurityContext: {}
   securityContext: {}
   annotations: {}
-  image: jaegertracing/jaeger-ingester
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-ingester
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   replicaCount: 1
@@ -307,10 +322,13 @@ agent:
   securityContext: {}
   enabled: true
   annotations: {}
-  image: jaegertracing/jaeger-agent
-  # tag: 1.22
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-agent
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   cmdlineParams: {}
   extraEnv: []
   daemonset:
@@ -386,10 +404,13 @@ collector:
   securityContext: {}
   enabled: true
   annotations: {}
-  image: jaegertracing/jaeger-collector
-  # tag: 1.22
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-collector
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   dnsPolicy: ClusterFirst
   extraEnv: []
   envFrom: []
@@ -560,8 +581,13 @@ query:
       # requests:
       #   cpu: 256m
       #   memory: 128Mi
-    image: quay.io/oauth2-proxy/oauth2-proxy:v7.1.0
-    pullPolicy: IfNotPresent
+    image:
+      registry: quay.io
+      repository: oauth2-proxy/oauth2-proxy
+      tag: v7.1.0
+      digest: ""
+      pullPolicy: IfNotPresent
+      pullSecrets: []
     containerPort: 4180
     args: []
     extraEnv: []
@@ -591,10 +617,13 @@ query:
   #        cpu: 256m
   #        memory: 128Mi
   annotations: {}
-  image: jaegertracing/jaeger-query
-  # tag: 1.22
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-query
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   dnsPolicy: ClusterFirst
   cmdlineParams: {}
   extraEnv: []
@@ -702,10 +731,13 @@ query:
 spark:
   enabled: false
   annotations: {}
-  image: jaegertracing/spark-dependencies
-  imagePullSecrets: []
-  tag: latest
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/spark-dependencies
+    tag: latest
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   cmdlineParams: {}
   extraEnv: []
   schedule: "49 23 * * *"
@@ -744,9 +776,13 @@ esIndexCleaner:
   podSecurityContext:
     runAsUser: 1000
   annotations: {}
-  image: jaegertracing/jaeger-es-index-cleaner
-  imagePullSecrets: []
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-es-index-cleaner
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   cmdlineParams: {}
   extraEnv:
     []
@@ -788,10 +824,13 @@ esRollover:
   podSecurityContext:
     runAsUser: 1000
   annotations: {}
-  image: jaegertracing/jaeger-es-rollover
-  imagePullSecrets: []
-  tag: latest
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-es-rollover
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   cmdlineParams: {}
   extraEnv:
     - name: CONDITIONS
@@ -839,10 +878,13 @@ esLookback:
   podSecurityContext:
     runAsUser: 1000
   annotations: {}
-  image: jaegertracing/jaeger-es-rollover
-  imagePullSecrets: []
-  tag: latest
-  pullPolicy: IfNotPresent
+  image:
+    registry: ""
+    repository: jaegertracing/jaeger-es-rollover
+    tag: ""
+    digest: ""
+    pullPolicy: IfNotPresent
+    pullSecrets: []
   cmdlineParams: {}
   extraEnv:
     - name: UNIT
@@ -896,7 +938,10 @@ hotrod:
   #   - name: OTEL_EXPORTER_OTLP_ENDPOINT
   #     value: http://my-otel-collector.chart.local:4318
   image:
+    registry: ""
     repository: jaegertracing/example-hotrod
+    tag: ""
+    digest: ""
     pullPolicy: IfNotPresent
     pullSecrets: []
   service:


### PR DESCRIPTION
#### What this PR does

- Splits image registry, repository, and tag. Allowing for overriding of any one without affecting the other
- Allow overriding the image registry in the global config
- Allow setting the pullSecrets at the global level

#### Which issue this PR fixes

- relates to  #182 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
