### PR TITLE
[jaeger] Update oauth sidecard to 7.6.0

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 2.0.0
+version: 2.0.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -355,7 +355,7 @@ query:
     image:
       registry: quay.io
       repository: oauth2-proxy/oauth2-proxy
-      tag: v7.3.0
+      tag: v7.6.0
     pullPolicy: IfNotPresent
     containerPort: 4180
     args:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -584,7 +584,7 @@ query:
     image:
       registry: quay.io
       repository: oauth2-proxy/oauth2-proxy
-      tag: v7.1.0
+      tag: v7.6.0
       digest: ""
       pullPolicy: IfNotPresent
       pullSecrets: []


### PR DESCRIPTION
#### What this PR does

Bump oauth2-proxy version

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
