### PR TITLE
[jaeger] Add badger support for AllInOne deployment

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 2.0.1
+version: 2.1.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -383,7 +383,36 @@ grpcPlugin related environment variables
 {{- end -}}
 
 {{/*
-Cassandra, Elasticsearch, or grpc-plugin related environment variables depending on which is used
+badger related environment variables
+*/}}
+{{- define "badger.env" -}}
+{{- if .Values.storage.badger.extraEnv }}
+{{- toYaml .Values.storage.badger.extraEnv }}
+{{- end }}
+{{- end -}}
+
+{{/*
+memory related environment variables
+*/}}
+{{- define "memory.env" -}}
+{{- if .Values.storage.memory.extraEnv }}
+{{- toYaml .Values.storage.memory.extraEnv }}
+{{- end }}
+{{- end -}}
+
+{{/*
+allInOne currently only supports memory/badger storage type.
+*/}}
+{{- define "allInOne.storage.type" -}}
+{{ $type := .Values.storage.type }}
+{{- if or (eq $type "memory") (eq $type "badger") -}}
+{{ .Values.storage.type }}
+{{- end -}}
+{{- end -}}
+
+
+{{/*
+Cassandra, Elasticsearch, or grpc-plugin, badger, memory related environment variables depending on which is used
 */}}
 {{- define "storage.env" -}}
 {{- if eq .Values.storage.type "cassandra" -}}
@@ -392,6 +421,10 @@ Cassandra, Elasticsearch, or grpc-plugin related environment variables depending
 {{ include "elasticsearch.env" . }}
 {{- else if eq .Values.storage.type "grpc-plugin" -}}
 {{ include "grpcPlugin.env" . }}
+{{- else if eq .Values.storage.type "badger" -}}
+{{ include "badger.env" . }}
+{{- else if eq .Values.storage.type "memory" -}}
+{{ include "memory.env" . }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -386,6 +386,14 @@ grpcPlugin related environment variables
 badger related environment variables
 */}}
 {{- define "badger.env" -}}
+- name: BADGER_EPHEMERAL
+  value: {{ .Values.storage.badger.ephemeral | quote }}
+{{- if not .Values.storage.badger.ephemeral }}
+- name: BADGER_DIRECTORY_VALUE
+  value: {{ print .Values.storage.badger.persistence.mountPath "/badger/data" | quote }}
+- name: BADGER_DIRECTORY_KEY
+  value: {{ print .Values.storage.badger.persistence.mountPath "/badger/key" | quote }}
+{{- end }}
 {{- if .Values.storage.badger.extraEnv }}
 {{- toYaml .Values.storage.badger.extraEnv }}
 {{- end }}

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -37,7 +37,8 @@ spec:
             {{- toYaml .Values.allInOne.extraEnv | nindent 12 }}
           {{- end }}
             - name: SPAN_STORAGE_TYPE
-              value: memory
+              value: {{ include "allInOne.storage.type" . | required "Invalid storage type provided. Use either badger or memory for allInOne" }}
+            {{- include "storage.env" . | nindent 12 }}
             - name: COLLECTOR_ZIPKIN_HOST_PORT
               value: :9411
             - name: JAEGER_DISABLED

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -103,6 +103,10 @@ spec:
         {{- toYaml . | nindent 12 }}
       {{- end }}
           volumeMounts:
+        {{- if not .Values.storage.badger.ephemeral }}
+            - name: badger-data
+              mountPath: {{ .Values.storage.badger.persistence.mountPath }}
+        {{- end }}
         {{- if .Values.allInOne.samplingConfig}}
             - name: strategies
               mountPath: /etc/conf/
@@ -113,8 +117,17 @@ spec:
               subPath: {{ .subPath }}
               readOnly: {{ .readOnly }}
         {{- end }}
+      securityContext:
+        runAsUser: 10001
+        runAsGroup: 10001
+        fsGroup: 10001
       serviceAccountName: {{ template "jaeger.fullname" . }}
       volumes:
+    {{- if not .Values.storage.badger.ephemeral }}
+        - name: badger-data
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.badger.persistence.useExistingPvcName | required "Using badger persistence it is required to set an existing PVC"  }}
+    {{- end }}
     {{- if .Values.allInOne.samplingConfig}}
         - name: strategies
           configMap:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -88,7 +88,7 @@ allInOne:
   nodeSelector: {}
 
 storage:
-  # allowed values (cassandra, elasticsearch)
+  # allowed values (cassandra, elasticsearch, grpc-plugin, badger, memory)
   type: cassandra
   cassandra:
     host: cassandra
@@ -166,6 +166,10 @@ storage:
     authentication: none
     extraEnv: []
   grpcPlugin:
+    extraEnv: []
+  badger:
+    extraEnv: []
+  memory:
     extraEnv: []
 
 # Begin: Override values on the Cassandra subchart to customize for Jaeger

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -168,6 +168,10 @@ storage:
   grpcPlugin:
     extraEnv: []
   badger:
+    ephemeral: true
+    persistence:
+      mountPath: /mnt/data
+      useExistingPvcName: ""
     extraEnv: []
   memory:
     extraEnv: []


### PR DESCRIPTION
#### What this PR does

Adds badger support for the AllInOne deployment. By default it uses ephemeral badger, but a user-provided PVC can be used to use persistence features. 

Conflicts with #527 because of the securityContext

#### Which issue this PR fixes

- fixes #511 
- fixes #390 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
