### PR TITLE
[jaeger-operator] Allow configuring extra command line arguments for jaeger operator

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.52.0
+version: 2.53.0
 appVersion: 1.52.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -68,6 +68,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `rbac.pspEnabled`           | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
 | `rbac.clusterRole`          | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
 | `serviceAccount.name`       | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
+| `extraArgs`                 | Additional command line arguments arguments passed to the operator                                          | `{}`                            |
 | `extraEnv`                  | Additional environment variables passed to the operator. For example: name: LOG-LEVEL value: debug          | `[]`                            |
 | `replicaCount`              | Desired number of operator pods                                                                             | `1`                             |
 | `resources`                 | K8s pod resources                                                                                           | `None`                          |

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -63,6 +63,13 @@ spec:
             {{- if gt $replicaCount 1 }}
             - --leader-elect
             {{- end }}
+            {{- range $key, $value := .Values.extraArgs }}
+            {{- if $value }}
+            - --{{ $key }}={{ $value }}
+            {{- else }}
+            - --{{ $key }}
+            {{- end }}
+            {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.rbac.clusterRole }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -61,6 +61,10 @@ serviceAccount:
   # Annotations for serviceAccount
   annotations: {}
 
+extraArgs: {}
+  # Specifies extra command line arguments arguments passed to the operator:
+  # foo: bar
+
 # Specifies extra environment variables passed to the operator:
 extraEnv: []
   # Specifies log-level for the operator:


### PR DESCRIPTION
#### What this PR does

Allow configuring extra command line arguments for jaeger operator.

#### Which issue this PR fixes

- fixes #232

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
