### PR TITLE
[jaeger-operator] Allow configuring replica count for jaeger operator

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.50.1
+version: 2.51.0
 appVersion: 1.52.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -69,6 +69,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `rbac.clusterRole`         | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
 | `serviceAccount.name`      | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
 | `extraEnv`                 | Additional environment variables passed to the operator. For example: name: LOG-LEVEL value: debug          | `[]`                            |
+| `replicaCount`             | Desired number of operator pods                                                                             | `1`                             |
 | `resources`                | K8s pod resources                                                                                           | `None`                          |
 | `nodeSelector`             | Node labels for pod assignment                                                                              | `{}`                            |
 | `tolerations`              | Toleration labels for pod assignment                                                                        | `[]`                            |

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
 {{ . | toYaml | indent 4 }}
 {{- end }}
 spec:
-  replicas: 1
+  replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
 {{ include "jaeger-operator.labels" . | indent 6 }}
@@ -59,6 +59,10 @@ spec:
             - start
             - {{ printf "--metrics-port=%v" .Values.metricsPort }}
             - {{ printf "--webhook-bind-port=%v" .Values.webhooks.port }}
+            {{- $replicaCount := int .Values.replicaCount }}
+            {{- if gt $replicaCount 1 }}
+            - --leader-elect
+            {{- end }}
           env:
             - name: WATCH_NAMESPACE
               {{- if .Values.rbac.clusterRole }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -75,6 +75,9 @@ extraLabels: {}
   # Specifies extra labels for the operator deployment:
   # foo: bar
 
+# Specifies desired number of operator pods
+replicaCount: 1
+
 resources: {}
   # limits:
   #  cpu: 100m


### PR DESCRIPTION
#### What this PR does

Allow configuring replica count for jaeger operator.

Enable leader election if the given number is greater than 1.

#### Which issue this PR fixes

`N/A`

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
