### PR TITLE
[jaeger-operator] Allow configuring topology spread constraints for jaeger operator

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.51.0
+version: 2.52.0
 appVersion: 1.52.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -55,28 +55,29 @@ The command removes all the Kubernetes components associated with the chart and 
 The following table lists the configurable parameters of the jaeger-operator chart and their default values.
 
 | Parameter                  | Description                                                                                                 | Default                         |
-| :------------------------- | :---------------------------------------------------------------------------------------------------------- |:--------------------------------|
-| `serviceExtraLabels`       | Additional labels to jaeger-operator service                                                                | `{}`                            |
-| `extraLabels`              | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
-| `image.repository`         | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`                | Controller container image tag                                                                              | `1.52.0`                        |
-| `image.pullPolicy`         | Controller container image pull policy                                                                      | `IfNotPresent`                  |
-| `jaeger.create`            | Jaeger instance will be created                                                                             | `false`                         |
-| `jaeger.spec`              | Jaeger instance specification                                                                               | `{}`                            |
-| `rbac.create`              | All required roles and rolebindings will be created                                                         | `true`                          |
-| `serviceAccount.create`    | Service account to use                                                                                      | `true`                          |
-| `rbac.pspEnabled`          | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
-| `rbac.clusterRole`         | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
-| `serviceAccount.name`      | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
-| `extraEnv`                 | Additional environment variables passed to the operator. For example: name: LOG-LEVEL value: debug          | `[]`                            |
-| `replicaCount`             | Desired number of operator pods                                                                             | `1`                             |
-| `resources`                | K8s pod resources                                                                                           | `None`                          |
-| `nodeSelector`             | Node labels for pod assignment                                                                              | `{}`                            |
-| `tolerations`              | Toleration labels for pod assignment                                                                        | `[]`                            |
-| `affinity`                 | Affinity settings for pod assignment                                                                        | `{}`                            |
-| `securityContext`          | Security context for pod                                                                                    | `{}`                            |
-| `containerSecurityContext` | Security context for the container                                                                          | `{}`                            |
-| `priorityClassName`        | Priority class name for the pod                                                                             | `None`                          |
+| :-------------------------- | :---------------------------------------------------------------------------------------------------------- |:--------------------------------|
+| `serviceExtraLabels`        | Additional labels to jaeger-operator service                                                                | `{}`                            |
+| `extraLabels`               | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
+| `image.repository`          | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
+| `image.tag`                 | Controller container image tag                                                                              | `1.52.0`                        |
+| `image.pullPolicy`          | Controller container image pull policy                                                                      | `IfNotPresent`                  |
+| `jaeger.create`             | Jaeger instance will be created                                                                             | `false`                         |
+| `jaeger.spec`               | Jaeger instance specification                                                                               | `{}`                            |
+| `rbac.create`               | All required roles and rolebindings will be created                                                         | `true`                          |
+| `serviceAccount.create`     | Service account to use                                                                                      | `true`                          |
+| `rbac.pspEnabled`           | Pod security policy for pod will be created and included in rbac role                                       | `false`                         |
+| `rbac.clusterRole`          | ClusterRole will be used by operator ServiceAccount                                                         | `false`                         |
+| `serviceAccount.name`       | Service account name to use. If not set and create is true, a name is generated using the fullname template | `nil`                           |
+| `extraEnv`                  | Additional environment variables passed to the operator. For example: name: LOG-LEVEL value: debug          | `[]`                            |
+| `replicaCount`              | Desired number of operator pods                                                                             | `1`                             |
+| `resources`                 | K8s pod resources                                                                                           | `None`                          |
+| `nodeSelector`              | Node labels for pod assignment                                                                              | `{}`                            |
+| `tolerations`               | Toleration labels for pod assignment                                                                        | `[]`                            |
+| `topologySpreadConstraints` | Topology Spread Constraints for pod assignment                                                              | `[]`                            |
+| `affinity`                  | Affinity settings for pod assignment                                                                        | `{}`                            |
+| `securityContext`           | Security context for pod                                                                                    | `{}`                            |
+| `containerSecurityContext`  | Security context for the container                                                                          | `{}`                            |
+| `priorityClassName`         | Priority class name for the pod                                                                             | `None`                          |
 
 Specify each parameter you'd like to override using a YAML file as described above in the [installation](#installing-the-chart) section.
 

--- a/charts/jaeger-operator/templates/deployment.yaml
+++ b/charts/jaeger-operator/templates/deployment.yaml
@@ -108,3 +108,7 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+{{ toYaml . | indent 8 }}
+    {{- end }}

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -90,6 +90,8 @@ nodeSelector: {}
 
 tolerations: []
 
+topologySpreadConstraints: []
+
 affinity: {}
 
 securityContext: {}


### PR DESCRIPTION
#### What this PR does

Allow configuring topology spread constraints for jaeger operator.

#### Which issue this PR fixes

`N/A`

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
