### PR TITLE
[jaeger] Elasticsearch chart migration

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -12,9 +12,9 @@ jobs:
           fetch-depth: 0
 
       - name: Set up Helm
-        uses: azure/setup-helm@v1
+        uses: azure/setup-helm@v4
         with:
-          version: v3.4.1
+          version: v3.14.4
 
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
@@ -24,9 +24,9 @@ jobs:
           python-version: 3.7
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.6.1
         with:
-          version: v3.3.0
+          version: v3.10.1
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -40,13 +40,13 @@ jobs:
         run: ct lint --config ct.yaml
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.2.0
+        uses: helm/kind-action@v1.9.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v2.0
+        uses: azure/setup-kubectl@v4.0.0
         with:
-          version: 'v1.22.0'
+          version: 'v1.28.8'
         id: install
 
       - name: Set up cert-manager

--- a/charts/jaeger/Chart.lock
+++ b/charts/jaeger/Chart.lock
@@ -3,13 +3,13 @@ dependencies:
   repository: https://charts.helm.sh/incubator
   version: 0.15.3
 - name: elasticsearch
-  repository: https://helm.elastic.co
-  version: 7.17.3
+  repository: https://charts.bitnami.com/bitnami
+  version: 20.0.4
 - name: kafka
   repository: https://charts.bitnami.com/bitnami
   version: 26.6.2
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.14.1
-digest: sha256:3c95910df1461e41daaa77958b63b7739c5291468ffbffd702dcc7550b5cf117
-generated: "2024-01-09T14:23:43.089557-05:00"
+  version: 2.19.1
+digest: sha256:16dad4387f2b392d5034731f997518ff05b77909220ce45ee6dd69664942f2df
+generated: "2024-04-11T08:42:48.824851-04:00"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 2.1.0
+version: 3.0.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:
@@ -32,11 +32,11 @@ dependencies:
     repository: https://charts.helm.sh/incubator
     condition: provisionDataStore.cassandra
   - name: elasticsearch
-    version: ^7.11.1
-    repository: https://helm.elastic.co
+    version: 20.0.4
+    repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.elasticsearch
   - name: kafka
-    version: ^26.6.2
+    version: 26.6.2
     repository: https://charts.bitnami.com/bitnami
     condition: provisionDataStore.kafka
   - name: common

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -259,8 +259,45 @@ schema:
     #   value: "0"
 
 # For configurable values of the elasticsearch if provisioned, please see:
-# https://github.com/elastic/helm-charts/tree/master/elasticsearch#configuration
+# https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch
 elasticsearch: {}
+
+# Example that uses no auth:
+# elasticsearch:
+#   fullnameOverride: "elasticsearch"
+#   image:
+#     registry: ""
+#     repository: docker.io/bitnami/elasticsearch
+#     tag: ""
+#   master:
+#     masterOnly: false
+#     replicaCount: 3
+#     extraEnvVars:
+#       - name: ES_JAVA_OPTS
+#         value: "-Xmx20g -Xms20g"
+#     persistence:
+#       enabled: true
+#       storageClass: managed-premium
+#       accessModes: [ "ReadWriteOnce" ]
+#       size: 100gb
+#   extraConfig:
+#     cluster.max_shards_per_node: 3000
+#   sysctlImage:
+#     registry: ""
+#     repository: docker.io/bitnami/os-shell
+#     tag: 12-debian-12-r18
+#   volumePermissions:
+#     enabled: true
+#     image:
+#       registry: ""
+#       repository: docker.io/bitnami/os-shell
+#       tag: 12-debian-12-r18
+#   data:
+#     replicaCount: 0
+#   coordinating:
+#     replicaCount: 0
+#   ingest:
+#     replicaCount: 0
 
 ingester:
   enabled: false


### PR DESCRIPTION
#### What this PR does

This PR changes the Elasticsearch helm chart to https://github.com/bitnami/charts/tree/main/bitnami/elasticsearch to migrate to a supported helm chart since the current one is deprecated. I bumped the major version since the helm chart is getting changed. 

I was able to get this to work with the default settings. Out of the box Elasticsearch doesn't have auth support unless `security.enabled` is set. 

To migrate existing workloads/data I was able to follow instructions on migrating the volumes to a new PVC thats created by the helm chart. This is similar to the Kafka migration that was done:
```
# Env variables
REPLICA=0
OLD_PVC="elasticsearch-master-elasticsearch-master-${REPLICA}"
NEW_PVC="data-elasticsearch-master-${REPLICA}"
PV_NAME=$(kubectl get pvc $OLD_PVC -o jsonpath="{.spec.volumeName}" -n <fill-in-namespace> )
NEW_PVC_MANIFEST_FILE="$NEW_PVC.yaml"

# Modify PV reclaim policy
kubectl patch pv $PV_NAME -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
# Manually check field 'RECLAIM POLICY'
kubectl get pv $PV_NAME

# Create new PVC manifest
kubectl get pvc $OLD_PVC -n <fill-in-namespace> -o json | jq "
  .metadata.name = \"$NEW_PVC\"
  | with_entries(
      select([.key] |
        inside([\"metadata\", \"spec\", \"apiVersion\", \"kind\"]))
    )
  | del(
      .metadata.annotations, .metadata.creationTimestamp,
      .metadata.finalizers, .metadata.resourceVersion,
      .metadata.selfLink, .metadata.uid
    )
  " > $NEW_PVC_MANIFEST_FILE
# Check manifest
cat $NEW_PVC_MANIFEST_FILE

# Delete your old Statefulset and PVC
kubectl delete sts "elasticsearch-master" -n <fill-in-namespace>
kubectl delete pvc $OLD_PVC -n <fill-in-namespace>
# Make PV available again and create the new PVC
kubectl patch pv $PV_NAME -p '{"spec":{"claimRef": null}}' -n <fill-in-namespace>
kubectl apply -f $NEW_PVC_MANIFEST_FILE -n <fill-in-namespace>
```

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
