### PR TITLE
Adding artifacthub-repo.yml to gh pages

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,25 @@
+# Artifact Hub repository metadata file
+#
+# Some settings like the verified publisher flag or the ignored packages won't
+# be applied until the next time the repository is processed. Please keep in
+# mind that the repository won't be processed if it has not changed since the
+# last time it was processed. Depending on the repository kind, this is checked
+# in a different way. For Helm http based repositories, we consider it has
+# changed if the `index.yaml` file changes. For git based repositories, it does
+# when the hash of the last commit in the branch you set up changes. This does
+# NOT apply to ownership claim operations, which are processed immediately.
+#
+#repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+owners: # (optional, used to claim repository ownership)
+  - name: mikelorant
+    email: michael.lorant@fairfaxmedia.com.au
+  - name: mehta-ankit
+    email: ankit.mehta@appian.com
+  - name: nessemkullah
+    email: naseem@transit.app
+  - name: pavelnikolov
+    email: me@pavelnikolov.net
+  - name: dvonthenen
+    email: david.vonthenen@dell.com
+  - name: jkowall
+    email: jkowall@kowall.net


### PR DESCRIPTION
#### What this PR does
Adds the file to gh-pages branch

#### Which issue this PR fixes
related to : https://github.com/jaegertracing/jaeger/issues/5363

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [NA] Chart Version bumped
- [NA] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [NA] README.md has been updated to match version/contain new values
