### PR TITLE
Adding official Artifact Hub ID

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -9,7 +9,7 @@
 # when the hash of the last commit in the branch you set up changes. This does
 # NOT apply to ownership claim operations, which are processed immediately.
 #
-#repositoryID: The ID of the Artifact Hub repository where the packages will be published to (optional, but it enables verified publisher)
+repositoryID: 34a4fca1-3824-4e31-a6ab-84da69901ad5
 owners: # (optional, used to claim repository ownership)
   - name: mikelorant
     email: michael.lorant@fairfaxmedia.com.au


### PR DESCRIPTION
#### What this PR does
Adds the ID from Artifact Hub to the yaml file 

#### Which issue this PR fixes
https://github.com/jaegertracing/jaeger/issues/5363

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [NA] Chart Version bumped
- [NA] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [NA] README.md has been updated to match version/contain new values
