### PR TITLE
[jaeger] correct indentation of imagePullSecrets in indexer and lookback cronjobs

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.4
+version: 3.0.5
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
+++ b/charts/jaeger/templates/es-index-cleaner-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esIndexCleaner.serviceAccountName" . }}
-          {{- include "esIndexCleaner.imagePullSecrets" . | nindent 12 }}
+          {{- include "esIndexCleaner.imagePullSecrets" . | nindent 10 }}
           securityContext:
             {{- toYaml .Values.esIndexCleaner.podSecurityContext | nindent 12 }}
           containers:

--- a/charts/jaeger/templates/es-lookback-cronjob.yaml
+++ b/charts/jaeger/templates/es-lookback-cronjob.yaml
@@ -38,7 +38,7 @@ spec:
             {{- end }}
         spec:
           serviceAccountName: {{ template "jaeger.esLookback.serviceAccountName" . }}
-          {{- include "esLookback.imagePullSecrets" . | nindent 12 }}  
+          {{- include "esLookback.imagePullSecrets" . | nindent 10 }}  
           securityContext:
             {{- toYaml .Values.esLookback.podSecurityContext | nindent 12 }}
           restartPolicy: OnFailure


### PR DESCRIPTION
#### What this PR does

Correct indentation of `imagePullSecrets` in indexer and lookback cronjobs.  This can be confirmed by running:
```
helm template . --set "global.imagePullSecrets.0=test" --set esIndexCleaner.enabled=true
helm template . --set "global.imagePullSecrets.0=test" --set esLookback.enabled=true
```
Both of these would previously fail with errors like
```
Error: YAML parse error on jaeger/templates/es-index-cleaner-cronjob.yaml: error converting YAML to JSON: yaml: line 29: mapping values are not allowed in this context
```

#### Which issue this PR fixes

- fixes [#556](https://github.com/jaegertracing/helm-charts/issues/556)

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
