### PR TITLE
[jaeger] quote host name in ingress templates

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.6
+version: 3.0.7
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/collector-ing.yaml
+++ b/charts/jaeger/templates/collector-ing.yaml
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   rules:
     {{- range .Values.collector.ingress.hosts }}
-    - host: {{ include "jaeger.collector.ingressHost" . }}
+    - host: {{ include "jaeger.collector.ingressHost" . | quote }}
       http:
         paths:
           - path: {{ $basePath }}

--- a/charts/jaeger/templates/hotrod-ing.yaml
+++ b/charts/jaeger/templates/hotrod-ing.yaml
@@ -20,7 +20,7 @@ spec:
   {{- end }}
   rules:
     {{- range $host := .Values.hotrod.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote}}
       http:
         paths:
           - path: /

--- a/charts/jaeger/templates/query-ing.yaml
+++ b/charts/jaeger/templates/query-ing.yaml
@@ -22,7 +22,7 @@ spec:
   {{- end }}
   rules:
     {{- range $host := .Values.query.ingress.hosts }}
-    - host: {{ $host }}
+    - host: {{ $host | quote }}
       http:
         paths:
           - path: {{ $basePath }}


### PR DESCRIPTION
#### What this PR does
Quote host name in ingress templates to prevents a yaml syntax error when using a host starting with a wildcard.

`helm template . --set "query.ingress.enabled=true" --set "query.ingress.hosts[0]=*.example.test"` now has this output:

```
...
---
# Source: jaeger/templates/query-ing.yaml
apiVersion: networking.k8s.io/v1
kind: Ingress
metadata:
  name: release-name-jaeger-query
  labels:
    helm.sh/chart: jaeger-3.0.7
    app.kubernetes.io/name: jaeger
    app.kubernetes.io/instance: release-name
    app.kubernetes.io/version: "1.53.0"
    app.kubernetes.io/managed-by: Helm
    app.kubernetes.io/component: query
spec:
  rules:
    - host: "*.example.test"
      http:
        paths:
          - path: /
            pathType: ImplementationSpecific
            backend:
              service:
                name: release-name-jaeger-query
                port:
                  number: 80
```

Before the change it would try to render with `- host: *.example.test` which is invalid YAML because of the value starting with a `*`.

#### Which issue this PR fixes

- fixes #571

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
