### PR TITLE
Fix typo in _helpers.tpl/renderImage for global

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.7
+version: 3.0.8
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -565,7 +565,7 @@ If not tag is provided, it defaults to .Chart.AppVersion.
 */}}
 {{- define "renderImage" -}}
 {{- $image := merge .imageRoot (dict "tag" .context.Chart.AppVersion) -}}
-{{- include "common.images.image" (dict "imageRoot" $image "global" .context.Values.Global) -}}
+{{- include "common.images.image" (dict "imageRoot" $image "global" .context.Values.global) -}}
 {{- end -}}
 
 {{/*

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -725,8 +725,8 @@ query:
   tolerations: []
   affinity: {}
   podAnnotations: {}
-  ## Additional pod labels
-  ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
+  # Additional pod labels
+  # ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
   podLabels: {}
   extraConfigmapMounts: []
   # - name: jaeger-config
@@ -736,11 +736,11 @@ query:
   #   readOnly: true
   extraVolumes: []
   sidecars: []
-  ##   - name: your-image-name
-  ##     image: your-image
-  ##     ports:
-  ##       - name: portname
-  ##         containerPort: 1234
+  #   - name: your-image-name
+  #     image: your-image
+  #     ports:
+  #       - name: portname
+  #         containerPort: 1234
   priorityClassName: ""
   serviceMonitor:
     enabled: false


### PR DESCRIPTION
#### What this PR does
Fixes typo in _helpers.tpl / renderImage for global

#### Which issue this PR fixes
use of globalRegistry

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
