### PR TITLE
[jaeger] Fix typo preventing use of global.imageRegistry

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.7
+version: 3.0.8
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -565,7 +565,7 @@ If not tag is provided, it defaults to .Chart.AppVersion.
 */}}
 {{- define "renderImage" -}}
 {{- $image := merge .imageRoot (dict "tag" .context.Chart.AppVersion) -}}
-{{- include "common.images.image" (dict "imageRoot" $image "global" .context.Values.Global) -}}
+{{- include "common.images.image" (dict "imageRoot" $image "global" .context.Values.global) -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
#### What this PR does
Fix typo preventing use of global.imageRegistry

#### Which issue this PR fixes
Fix typo preventing use of global.imageRegistry

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
