### PR TITLE
[jaeger] Fix Error: INSTALLATION FAILED: execution error at (jaeger/t…

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.8
+version: 3.1.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -302,7 +302,7 @@ provisionDataStore:
 allInOne:
   enabled: true
 storage:
-  type: none
+  type: memory
 agent:
   enabled: false
 collector:


### PR DESCRIPTION
Fix Error: INSTALLATION FAILED: execution error at (jaeger/templates/allinone-deploy.yaml:40:60): Invalid storage type provided. Use either badger or memory for allInOne

#### What this PR does

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
