### PR TITLE
[jaeger] Added missing quotes to README.md

### DIFF
--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -399,7 +399,7 @@ extraObjects:
   - apiVersion: rbac.authorization.k8s.io/v1
     kind: RoleBinding
     metadata:
-      name: {{ .Release.Name }}-someRoleBinding
+      name: "{{ .Release.Name }}-someRoleBinding"
     roleRef:
       apiGroup: rbac.authorization.k8s.io
       kind: Role


### PR DESCRIPTION
#### What this PR does

Add missing quotes to `extraObjects` to fix invalid YAML in example in README.md

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] ~Chart Version bumped~ N/A
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [X] README.md has been updated to match version/contain new values
