### PR TITLE
[jaeger] add new options, improvements into allInOne

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.0.10
+version: 3.1.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -138,6 +138,10 @@ spec:
           secret:
             secretName: {{ .secretName }}
     {{- end }}
+    {{- with .Values.allInOne.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.allInOne.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -142,6 +142,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.allInOne.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.allInOne.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -52,6 +52,8 @@ spec:
         {{- with .Values.allInOne.envFrom }}
           envFrom: {{- toYaml . | nindent 12 }}
         {{- end }}
+          securityContext:
+            {{- toYaml .Values.allInOne.securityContext | nindent 12 }}
           image: {{ include "allInOne.image" . }}
           imagePullPolicy: {{ .Values.allInOne.image.pullPolicy }}
           name: jaeger
@@ -118,9 +120,7 @@ spec:
               readOnly: {{ .readOnly }}
         {{- end }}
       securityContext:
-        runAsUser: 10001
-        runAsGroup: 10001
-        fsGroup: 10001
+        {{- toYaml .Values.allInOne.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
       volumes:
     {{- if not .Values.storage.badger.ephemeral }}

--- a/charts/jaeger/templates/allinone-sa.yaml
+++ b/charts/jaeger/templates/allinone-sa.yaml
@@ -10,4 +10,5 @@ metadata:
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
+automountServiceAccountToken: {{ .Values.allInOne.serviceAccount.automountServiceAccountToken }}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -88,6 +88,7 @@ allInOne:
   #     memory: 128Mi
   nodeSelector: {}
   affinity: {}
+  topologySpreadContraints: []
 
 storage:
   # allowed values (cassandra, elasticsearch, grpc-plugin, badger, memory)

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -89,6 +89,11 @@ allInOne:
   nodeSelector: {}
   affinity: {}
   topologySpreadContraints: []
+  podSecurityContext:
+    runAsUser: 10001
+    runAsGroup: 10001
+    fsGroup: 10001
+  securityContext: {}
 
 storage:
   # allowed values (cassandra, elasticsearch, grpc-plugin, badger, memory)

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -49,6 +49,7 @@ allInOne:
   #   }
   serviceAccount:
     annotations: {}
+    automountServiceAccountToken: true
   service:
     headless: true
     collector:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -87,6 +87,7 @@ allInOne:
   #     cpu: 256m
   #     memory: 128Mi
   nodeSelector: {}
+  affinity: {}
 
 storage:
   # allowed values (cassandra, elasticsearch, grpc-plugin, badger, memory)


### PR DESCRIPTION
#### What this PR does
- [jaeger] allInOne add option `automountServiceAccountToken` for serviceaccount
- [jaeger] allInOne add `affinity` support
- [jaeger] allInOne add `topologySpreadConstraints` support
- [jaeger] allInOne add `podSecurityContext` and `containerSecurityContext` support

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
