### PR TITLE
[jaeger] Add securityContext for spark cron job

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.1.0
+version: 3.1.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/spark-cronjob.yaml
+++ b/charts/jaeger/templates/spark-cronjob.yaml
@@ -38,6 +38,8 @@ spec:
         spec:
           serviceAccountName: {{ template "jaeger.spark.serviceAccountName" . }}
           {{- include "spark.imagePullSecrets" . | nindent 10 }}
+          securityContext:
+            {{- toYaml .Values.spark.podSecurityContext | nindent 12 }}
           containers:
           - name: {{ include "jaeger.fullname" . }}-spark
             image: {{ include "spark.image" . }}
@@ -76,6 +78,8 @@ spec:
                 subPath: {{ .subPath }}
                 readOnly: {{ .readOnly }}
             {{- end }}
+            securityContext:
+              {{- toYaml .Values.spark.securityContext | nindent 14 }}
           restartPolicy: OnFailure
           volumes:
           {{- range .Values.spark.extraConfigmapMounts }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -783,6 +783,8 @@ query:
 
 spark:
   enabled: false
+  securityContext: {}
+  podSecurityContext: {}
   annotations: {}
   image:
     registry: ""


### PR DESCRIPTION
#### What this PR does

Adding possibility to configure securityContext for spark CronJob

#### Which issue this PR fixes
- 
#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
