### PR TITLE
[jaeger] Add ability to edit port name and target port name in query and collector services

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.1.1
+version: 3.1.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.1.2
+version: 3.1.2:
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.1.2:
+version: 3.1.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -61,7 +61,7 @@ spec:
     targetPort: {{ .Values.collector.service.otlp.http.name }}
 {{- end }}
   - name: {{ .Values.collector.service.admin.name }}
-    port: {{ .Values.collector.service.admin.port }}
+    port: 14269
     targetPort: {{ .Values.collector.service.admin.targetPort }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -60,9 +60,9 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.collector.service.otlp.http.name }}
 {{- end }}
-  - name: admin
+  - name: {{ .Values.collector.service.portName | default "admin" }}
     port: 14269
-    targetPort: admin
+    targetPort: {{ .Values.collector.service.targetPortName | default "admin" }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -60,9 +60,9 @@ spec:
     protocol: TCP
     targetPort: {{ .Values.collector.service.otlp.http.name }}
 {{- end }}
-  - name: {{ .Values.collector.service.portName | default "admin" }}
-    port: 14269
-    targetPort: {{ .Values.collector.service.targetPortName | default "admin" }}
+  - name: {{ .Values.collector.service.admin.name }}
+    port: {{ .Values.collector.service.admin.port }}
+    targetPort: {{ .Values.collector.service.admin.targetPort }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: collector

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -23,10 +23,10 @@ spec:
     port: 16685
     protocol: TCP
     targetPort: grpc
-  - name: {{ .Values.query.service.portName | default "admin" }}
+  - name: {{ .Values.query.service.admin.name }}
     port: 16687
     protocol: TCP
-    targetPort: {{ .Values.query.service.targetPortName | default "admin" }}
+    targetPort: {{ .Values.query.service.admin.targetPort }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -23,10 +23,10 @@ spec:
     port: 16685
     protocol: TCP
     targetPort: grpc
-  - name: admin
+  - name: {{ .Values.query.service.portName | default "admin" }}
     port: 16687
     protocol: TCP
-    targetPort: admin
+    targetPort: {{ .Values.query.service.targetPortName | default "admin" }}
   selector:
     {{- include "jaeger.selectorLabels" . | nindent 4 }}
     app.kubernetes.io/component: query

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -511,10 +511,8 @@ collector:
         # port: 4318
         # nodePort:
     admin:
-        {}
-#      name: "admin"
-#      port: 14269
-#      targetPort: "admin"
+      name: "admin"
+      targetPort: "admin"
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -699,9 +697,8 @@ query:
     # Specify a specific node port when type is NodePort
     # nodePort: 32500
     admin:
-       {}
-#      name: admin
-#      targetPort: admin
+      name: admin
+      targetPort: admin
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -510,6 +510,11 @@ collector:
         # name: otlp-http
         # port: 4318
         # nodePort:
+    admin:
+        {}
+#      name: "admin"
+#      port: 14269
+#      targetPort: "admin"
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName
@@ -693,6 +698,10 @@ query:
     # targetPort: 8080
     # Specify a specific node port when type is NodePort
     # nodePort: 32500
+    admin:
+       {}
+#      name: admin
+#      targetPort: admin
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -511,8 +511,8 @@ collector:
         # port: 4318
         # nodePort:
     admin:
-      name: "admin"
-      targetPort: "admin"
+      name: admin
+      targetPort: admin
   ingress:
     enabled: false
     # For Kubernetes >= 1.18 you should specify the ingress-controller via the field ingressClassName


### PR DESCRIPTION
#### What this PR does
This PR adds the ability to edit the port name and target port name in the Jaeger query and collector services. This enhancement allows users to customize the port names, which is useful for enforcing HTTPS via Istio by renaming the port with the prefix http.

#### Which issue this PR fixes
This PR fixes issue [#589](https://github.com/jaegertracing/helm-charts/issues/589).

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
