### PR TITLE
[jaeger-operator] Add ingressclasses to role.yaml so that the CRD has correct permissions when rbac.cluster.Role is set

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.54.0
+version: 2.55.0
 appVersion: 1.57.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/role.yaml
+++ b/charts/jaeger-operator/templates/role.yaml
@@ -130,6 +130,7 @@ rules:
   - extensions
   resources:
   - ingresses
+  - ingressclasses
   verbs:
   - create
   - delete


### PR DESCRIPTION
#### What this PR does
Add ingressclasses to role.yaml so that the CRD has correct permissions when rbac.cluster.Role is set
#### Which issue this PR fixes
- fixes #581 

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [X] README.md has been updated to match version/contain new values
