### PR TITLE
[jaeger-operator] Add ingressclasses to correct apiGroup

### DIFF
--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.55.0
+version: 2.56.0
 appVersion: 1.57.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg

--- a/charts/jaeger-operator/templates/role.yaml
+++ b/charts/jaeger-operator/templates/role.yaml
@@ -130,7 +130,6 @@ rules:
   - extensions
   resources:
   - ingresses
-  - ingressclasses
   verbs:
   - create
   - delete
@@ -233,6 +232,13 @@ rules:
   - list
   - patch
   - update
+  - watch
+- apiGroups:
+  - networking.k8s.io
+  resources:
+  - ingressclasses
+  verbs:
+  - list
   - watch
 - apiGroups:
   - rbac.authorization.k8s.io


### PR DESCRIPTION
#### What this PR does
[Original fix](https://github.com/jaegertracing/helm-charts/pull/591) added ingressclasses to `extensions` instead of `networking.k8s.io`

#### Which issue this PR fixes

- fixes https://github.com/jaegertracing/helm-charts/issues/581
- fixes https://github.com/jaegertracing/helm-charts/issues/593

Error in logs:
```
~ kubectl logs -n jaeger jaeger-operator-6867cc744c-6pq6z
W0731 09:34:51.891865       1 reflector.go:539] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: 
  failed to list *v1.IngressClass: ingressclasses.networking.k8s.io is forbidden:
  User "system:serviceaccount:jaeger:jaeger-operator" cannot list resource "ingressclasses" in API group "networking.k8s.io" at the cluster scope

E0731 09:34:51.891968       1 reflector.go:147] pkg/mod/k8s.io/client-go@v0.29.3/tools/cache/reflector.go:229: 
  Failed to watch *v1.IngressClass: failed to list *v1.IngressClass: ingressclasses.networking.k8s.io is forbidden:
  User "system:serviceaccount:jaeger:jaeger-operator" cannot list resource "ingressclasses" in API group "networking.k8s.io" at the cluster scope
```

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
