### PR TITLE
[jaeger] Add cassandra schema job toleration

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.1.3
+version: 3.2.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/cassandra-schema-job.yaml
+++ b/charts/jaeger/templates/cassandra-schema-job.yaml
@@ -96,6 +96,10 @@ spec:
           secret:
             secretName: {{ .Values.storage.cassandra.tls.secretName }}
       {{- end }}
+    {{- with .Values.schema.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -232,6 +232,7 @@ kafka:
 # use by Jaeger
 schema:
   annotations: {}
+  tolerations: []
   image:
     registry: ""
     repository: jaegertracing/jaeger-cassandra-schema


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

* Adds cassandra schma job toleration

- fixes #547 which didn't have a GPG-signed commit

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
