### PR TITLE
[jaeger] Add securityContext for the oauth sidecar in query-deploy.yaml

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.2.0
+version: 3.2.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -136,6 +136,8 @@ spec:
             port: admin
 {{- if .Values.query.oAuthSidecar.enabled }}
       - name: {{ template "jaeger.agent.name" . }}-oauth2-sidecar
+        securityContext:
+          {{- toYaml .Values.query.securityContext | nindent 10 }}
         image: {{ include "oAuthSidecar.image" . }}
         imagePullPolicy: {{ .Values.query.oAuthSidecar.image.pullPolicy }}
         args:


### PR DESCRIPTION
#### What this PR does

The sidecar is missing the securityContext entry, and it makes it difficult to apply specific settings in the context of K8s PSS (migrating from PSP for example).

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
