### PR TITLE
[Jaeger] Jaeger allInOne allow different storage types

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.3.0
+version: 3.3.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -408,16 +408,6 @@ memory related environment variables
 {{- end }}
 {{- end -}}
 
-{{/*
-allInOne currently only supports memory/badger storage type.
-*/}}
-{{- define "allInOne.storage.type" -}}
-{{ $type := .Values.storage.type }}
-{{- if or (eq $type "memory") (eq $type "badger") -}}
-{{ .Values.storage.type }}
-{{- end -}}
-{{- end -}}
-
 
 {{/*
 Cassandra, Elasticsearch, or grpc-plugin, badger, memory related environment variables depending on which is used

--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -37,7 +37,7 @@ spec:
             {{- toYaml .Values.allInOne.extraEnv | nindent 12 }}
           {{- end }}
             - name: SPAN_STORAGE_TYPE
-              value: {{ include "allInOne.storage.type" . | required "Invalid storage type provided. Use either badger or memory for allInOne" }}
+              value: {{ .Values.storage.type }}
             {{- include "storage.env" . | nindent 12 }}
             - name: COLLECTOR_ZIPKIN_HOST_PORT
               value: :9411


### PR DESCRIPTION
#### What this PR does
Allow different storage backend type for allInOne than just memory/badger.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes # https://github.com/jaegertracing/helm-charts/issues/602

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [] README.md has been updated to match version/contain new values
