### PR TITLE
Share setup sub-action in CI

### DIFF
--- a/.github/actions/prepare-k8s/action.yaml
+++ b/.github/actions/prepare-k8s/action.yaml
@@ -2,11 +2,6 @@ name: Prepare K8s for Helm tests
 runs:
   using: "composite"
   steps:
-    - name: Checkout
-      uses: actions/checkout@v2
-      with:
-        fetch-depth: 0
-
     - name: Set up Helm
       uses: azure/setup-helm@v4
       with:

--- a/.github/actions/prepare-k8s/action.yaml
+++ b/.github/actions/prepare-k8s/action.yaml
@@ -19,22 +19,8 @@ runs:
       with:
         version: v3.10.1
 
-    - name: Run chart-testing (list-changed)
-      shell: bash
-      id: list-changed
-      run: |
-        changed=$(ct list-changed --config ct.yaml)
-        if [[ -n "$changed" ]]; then
-          echo "::set-output name=changed::true"
-        fi
-
-    - name: Run chart-testing (lint)
-      shell: bash
-      run: ct lint --config ct.yaml
-
     - name: Create kind cluster
       uses: helm/kind-action@v1.9.0
-      if: steps.list-changed.outputs.changed == 'true'
 
     - name: Install kubectl
       uses: azure/setup-kubectl@v4.0.0

--- a/.github/actions/prepare-k8s/action.yaml
+++ b/.github/actions/prepare-k8s/action.yaml
@@ -20,6 +20,7 @@ runs:
         version: v3.10.1
 
     - name: Run chart-testing (list-changed)
+      shell: bash
       id: list-changed
       run: |
         changed=$(ct list-changed --config ct.yaml)
@@ -28,6 +29,7 @@ runs:
         fi
 
     - name: Run chart-testing (lint)
+      shell: bash
       run: ct lint --config ct.yaml
 
     - name: Create kind cluster
@@ -41,6 +43,7 @@ runs:
       id: install
 
     - name: Set up cert-manager
+      shell: bash
       run: |
         kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml --namespace ingress-nginx
         kubectl label node --all ingress-ready=true
@@ -49,6 +52,7 @@ runs:
         kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
 
     - name: Set up cmctl
+      shell: bash
       run: |
         curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.6.1/cmctl-linux-amd64.tar.gz
         tar xzf cmctl.tar.gz
@@ -56,5 +60,6 @@ runs:
         cmctl version
 
     - name: Check if cert-manager is up
+      shell: bash
       run: |
         cmctl check api --wait=5m

--- a/.github/actions/prepare-k8s/action.yaml
+++ b/.github/actions/prepare-k8s/action.yaml
@@ -1,0 +1,65 @@
+name: Prepare K8s for Helm tests
+runs:
+  using: "composite"
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 0
+
+    - name: Set up Helm
+      uses: azure/setup-helm@v4
+      with:
+        version: v3.14.4
+
+    # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
+    # yamllint (https://github.com/adrienverge/yamllint) which require Python
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.7
+
+    - name: Set up chart-testing
+      uses: helm/chart-testing-action@v2.6.1
+      with:
+        version: v3.10.1
+
+    - name: Run chart-testing (list-changed)
+      id: list-changed
+      run: |
+        changed=$(ct list-changed --config ct.yaml)
+        if [[ -n "$changed" ]]; then
+          echo "::set-output name=changed::true"
+        fi
+
+    - name: Run chart-testing (lint)
+      run: ct lint --config ct.yaml
+
+    - name: Create kind cluster
+      uses: helm/kind-action@v1.9.0
+      if: steps.list-changed.outputs.changed == 'true'
+
+    - name: Install kubectl
+      uses: azure/setup-kubectl@v4.0.0
+      with:
+        version: 'v1.28.8'
+      id: install
+
+    - name: Set up cert-manager
+      run: |
+        kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml --namespace ingress-nginx
+        kubectl label node --all ingress-ready=true
+        kubectl describe pod --selector=app.kubernetes.io/component=controller -n ingress-nginx
+        kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=5m
+        kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
+
+    - name: Set up cmctl
+      run: |
+        curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.6.1/cmctl-linux-amd64.tar.gz
+        tar xzf cmctl.tar.gz
+        sudo mv cmctl /usr/local/bin
+        cmctl version
+
+    - name: Check if cert-manager is up
+      run: |
+        cmctl check api --wait=5m

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -3,11 +3,10 @@ name: Lint and Test Charts
 on: pull_request
 
 jobs:
-  lint-test:
+  lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
@@ -39,34 +38,10 @@ jobs:
       - name: Run chart-testing (lint)
         run: ct lint --config ct.yaml
 
-      - name: Create kind cluster
-        uses: helm/kind-action@v1.9.0
-        if: steps.list-changed.outputs.changed == 'true'
-
-      - name: Install kubectl
-        uses: azure/setup-kubectl@v4.0.0
-        with:
-          version: 'v1.28.8'
-        id: install
-
-      - name: Set up cert-manager
-        run: |
-          kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml --namespace ingress-nginx
-          kubectl label node --all ingress-ready=true
-          kubectl describe pod --selector=app.kubernetes.io/component=controller -n ingress-nginx
-          kubectl wait --namespace ingress-nginx --for=condition=ready pod --selector=app.kubernetes.io/component=controller --timeout=5m
-          kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/releases/download/v1.6.1/cert-manager.yaml
-
-      - name: Set up cmctl
-        run: |
-          curl -sSL -o cmctl.tar.gz https://github.com/cert-manager/cert-manager/releases/download/v1.6.1/cmctl-linux-amd64.tar.gz
-          tar xzf cmctl.tar.gz
-          sudo mv cmctl /usr/local/bin
-          cmctl version
-
-      - name: Check if cert-manager is up
-        run: |
-          cmctl check api --wait=5m
+  test-with-cassandra:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/actions/prepare-k8s
 
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -41,6 +41,10 @@ jobs:
   test-with-cassandra:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - uses: ./.github/actions/prepare-k8s
 
       - name: Run chart-testing (install)


### PR DESCRIPTION
#### What this PR does

* Extracts common k8s setup steps into a reusable action
* Move install test into a separate job

#### Which issue this PR fixes

The CI testing of the chart does not cover installing 3rd party storage backends. PR #614 adds an extra test but either has to do it sequentially within the single job or replicate a lot of setup for another job / workflow. With this refactoring #614 would be able to add a new job to the existing workflow with minimal amount of boiler plate.

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
