### PR TITLE
[jaeger] Fix hostname for Elasticsearch service and add CI test

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -47,7 +47,7 @@ jobs:
 
       - uses: ./.github/actions/prepare-k8s
 
-      - name: Run chart-testing (install)
+      - name: Run cassandra-chart-testing (install)
         run: ct install --config ct.yaml
   test-with-allInOne:
     runs-on: ubuntu-latest
@@ -57,6 +57,8 @@ jobs:
           fetch-depth: 0
 
       - uses: ./.github/actions/prepare-k8s
+
+      - name: Run allInOne-chart-testing (install)
         run: |
           ct install --config ct.yaml --helm-extra-set-args "
             --set provisionDataStore.cassandra=false
@@ -71,6 +73,7 @@ jobs:
         - uses: actions/checkout@v2
           with:
             fetch-depth: 0
+
         - uses: ./.github/actions/prepare-k8s
 
         - name: Run elasticsearch-chart-testing (install)

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -49,3 +49,38 @@ jobs:
 
       - name: Run chart-testing (install)
         run: ct install --config ct.yaml
+  test-with-allInOne:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-k8s
+        run: |
+          ct install --config ct.yaml --helm-extra-set-args "
+            --set provisionDataStore.cassandra=false
+            --set storage.type=memory
+            --set allInOne.enabled=true
+            --set agent.enabled=false
+            --set collector.enabled=false
+            --set query.enabled=false"
+  test-with-elasticsearch:
+    runs-on: ubuntu-latest
+    steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: 0
+        - uses: ./.github/actions/prepare-k8s
+
+        - name: Run elasticsearch-chart-testing (install)
+          run: |
+            ct install --config ct.yaml --helm-extra-set-args "
+              --set provisionDataStore.cassandra=false
+              --set provisionDataStore.elasticsearch=true
+              --set storage.type=elasticsearch
+              --set elasticsearch.master.masterOnly=false
+              --set elasticsearch.master.replicaCount=1
+              --set elasticsearch.data.replicaCount=0
+              --set elasticsearch.coordinating.replicaCount=0
+              --set elasticsearch.ingest.replicaCount=0"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.3.1
+version: 3.3.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -272,6 +272,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- if .Values.provisionDataStore.elasticsearch }}
 {{- $host = printf "%s-elasticsearch" .Release.Name }}
 {{- end }}
+{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme $host $port }}
 {{- end -}}
 
 {{- define "jaeger.hotrod.tracing.host" -}}

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -268,7 +268,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "elasticsearch.client.url" -}}
 {{- $port := .Values.storage.elasticsearch.port | toString -}}
-{{- printf "%s://%s:%s" .Values.storage.elasticsearch.scheme .Values.storage.elasticsearch.host $port }}
+{{- $host := .Values.storage.elasticsearch.host }}
+{{- if .Values.provisionDataStore.elasticsearch }}
+{{- $host = printf "%s-elasticsearch" .Release.Name }}
+{{- end }}
 {{- end -}}
 
 {{- define "jaeger.hotrod.tracing.host" -}}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -32,6 +32,20 @@ spec:
         {{- toYaml .Values.collector.podLabels | nindent 8 }}
 {{- end }}
     spec:
+       {{- if .Values.provisionDataStore.elasticsearch }}
+      initContainers:
+        - name: elasticsearch-checker
+          image: curlimages/curl
+          command: 
+          - sh
+          - "-c"
+          - |
+            url="{{ include "elasticsearch.client.url" . }}"
+            until [ "$(curl -s -o /dev/null -w '%{http_code}' "$url/_cluster/health")" = "200" ]; do
+              echo "Waiting for Elasticsearch at $url"
+              sleep 5
+            done
+      {{- end}}
       {{- with .Values.collector.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -44,10 +44,25 @@ spec:
         {{- toYaml .Values.query.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.query.serviceAccountName" . }}
       {{- include "query.imagePullSecrets" . | nindent 6 }}
-      {{- if .Values.query.initContainers }}
+      {{- if or .Values.query.initContainers .Values.provisionDataStore.elasticsearch }}
       initContainers:
-      {{- toYaml .Values.query.initContainers | nindent 8 }}
-      {{- end}} 
+       {{- if .Values.query.initContainers }}
+        {{- toYaml .Values.query.initContainers | nindent 8 }}
+        {{- end }}
+        {{- if .Values.provisionDataStore.elasticsearch }}
+        - name: elasticsearch-checker
+          image: curlimages/curl
+          command: 
+          - sh
+          - "-c"
+          - |
+            url="{{ include "elasticsearch.client.url" . }}"
+            until [ "$(curl -s -o /dev/null -w '%{http_code}' "$url/_cluster/health")" = "200" ]; do
+              echo "waiting for Elasticsearch at $url"
+              sleep 5
+            done
+        {{- end }}
+      {{- end }}  
       containers:
       - name: {{ template "jaeger.query.name" . }}
         securityContext:


### PR DESCRIPTION
#### What this PR does

#### Which issue this PR fixes

- fixes #
1) the service name for the elastic search was not matching with jaeger-collector/query deployment 
2) added ci test for it 

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
