### PR TITLE
[jaeger] Make curl image respect global.imageRegistry

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.3.2
+version: 3.3.3
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -718,6 +718,18 @@ Create image name for hotrod image
 {{- end -}}
 
 {{/*
+Define curl image declaration
+*/}}
+{{- define "curl.image" -}}
+{{- $image := "curlimages/curl" -}}
+{{- if .Values.global.imageRegistry -}}
+{{ .Values.global.imageRegistry }}/{{ $image }}
+{{- else -}}
+{{ $image }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create pull secrets for hotrod image
 */}}
 {{- define "hotrod.imagePullSecrets" -}}

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -35,7 +35,7 @@ spec:
        {{- if .Values.provisionDataStore.elasticsearch }}
       initContainers:
         - name: elasticsearch-checker
-          image: curlimages/curl
+          image: {{ include "curl.image" . }}
           command: 
           - sh
           - "-c"

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -51,7 +51,7 @@ spec:
         {{- end }}
         {{- if .Values.provisionDataStore.elasticsearch }}
         - name: elasticsearch-checker
-          image: curlimages/curl
+          image: {{ include "curl.image" . }}
           command: 
           - sh
           - "-c"


### PR DESCRIPTION
#### What this PR does
This PR makes the curl image that is used for elasticsearch respect `global.imageRegistry`, such that:
```sh
helm template --set provisionDataStore.elasticsearch=true . | grep curlimages
          image: curlimages/curl
          image: curlimages/curl
```
```sh
helm template --set provisionDataStore.elasticsearch=true,global.imageRegistry=example.com . | grep curlimages
          image: example.com/curlimages/curl
          image: example.com/curlimages/curl
```

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
