### PR TITLE
[jaeger-operator] Upgrade to 1.62.0

### DIFF
--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -2,6 +2,7 @@ The following table shows the compatibility of `Jaeger Operator helm chart` with
 
 | Chart version             | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |---------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.57.0                    | v1.61.x         | v1.19 to v1.29  | v0.32              | v1.6.1+      |
 | 2.54.0                    | v1.57.x         | v1.19 to v1.29  | v0.32              | v1.6.1+      |
 | 2.50.0                    | v1.52.x         | v1.19 to v1.28  | v0.32              | v1.6.1+      |
 | 2.49.0                    | v1.49.x         | v1.19 to v1.28  | v0.32              | v1.6.1+      |

--- a/charts/jaeger-operator/COMPATIBILITY.md
+++ b/charts/jaeger-operator/COMPATIBILITY.md
@@ -2,6 +2,7 @@ The following table shows the compatibility of `Jaeger Operator helm chart` with
 
 | Chart version             | Jaeger Operator | Kubernetes      | Strimzi Operator   | Cert-Manager |
 |---------------------------|-----------------|-----------------|--------------------|--------------|
+| 2.58.0                    | v1.62.x         | v1.19 to v1.29  | v0.32              | v1.6.1+      |
 | 2.57.0                    | v1.61.x         | v1.19 to v1.29  | v0.32              | v1.6.1+      |
 | 2.54.0                    | v1.57.x         | v1.19 to v1.29  | v0.32              | v1.6.1+      |
 | 2.50.0                    | v1.52.x         | v1.19 to v1.28  | v0.32              | v1.6.1+      |

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.56.0
-appVersion: 1.57.0
+version: 2.57.0
+appVersion: 1.61.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/Chart.yaml
+++ b/charts/jaeger-operator/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 description: jaeger-operator Helm chart for Kubernetes
 name: jaeger-operator
-version: 2.57.0
-appVersion: 1.61.0
+version: 2.58.0
+appVersion: 1.62.0
 home: https://www.jaegertracing.io/
 icon: https://www.jaegertracing.io/img/jaeger-icon-reverse-color.svg
 sources:

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `serviceExtraLabels`        | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`               | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`          | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`                 | Controller container image tag                                                                              | `1.57.0`                        |
+| `image.tag`                 | Controller container image tag                                                                              | `1.61.0`                        |
 | `image.pullPolicy`          | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`             | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`               | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/README.md
+++ b/charts/jaeger-operator/README.md
@@ -59,7 +59,7 @@ The following table lists the configurable parameters of the jaeger-operator cha
 | `serviceExtraLabels`        | Additional labels to jaeger-operator service                                                                | `{}`                            |
 | `extraLabels`               | Additional labels to jaeger-operator deployment                                                             | `{}`                            |
 | `image.repository`          | Controller container image repository                                                                       | `jaegertracing/jaeger-operator` |
-| `image.tag`                 | Controller container image tag                                                                              | `1.61.0`                        |
+| `image.tag`                 | Controller container image tag                                                                              | `1.62.0`                        |
 | `image.pullPolicy`          | Controller container image pull policy                                                                      | `IfNotPresent`                  |
 | `jaeger.create`             | Jaeger instance will be created                                                                             | `false`                         |
 | `jaeger.spec`               | Jaeger instance specification                                                                               | `{}`                            |

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.61.0
+  tag: 1.62.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 

--- a/charts/jaeger-operator/values.yaml
+++ b/charts/jaeger-operator/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: jaegertracing/jaeger-operator
-  tag: 1.57.0
+  tag: 1.61.0
   pullPolicy: IfNotPresent
   imagePullSecrets: []
 


### PR DESCRIPTION
#### What this PR does

Upgrade `jaeger-operator` application version to `1.62.0`

#### Which issue this PR fixes

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
