### PR TITLE
[jaeger] Support gRPC storage in Jaeger >=1.60.0

### DIFF
--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -421,7 +421,7 @@ Cassandra, Elasticsearch, or grpc-plugin, badger, memory related environment var
 {{ include "cassandra.env" . }}
 {{- else if eq .Values.storage.type "elasticsearch" -}}
 {{ include "elasticsearch.env" . }}
-{{- else if eq .Values.storage.type "grpc-plugin" -}}
+{{- else if or (eq .Values.storage.type "grpc-plugin") (eq .Values.storage.type "grpc") -}}
 {{ include "grpcPlugin.env" . }}
 {{- else if eq .Values.storage.type "badger" -}}
 {{ include "badger.env" . }}


### PR DESCRIPTION
The keyword changed, so we have to carry the env vars with us in that case.

#### What this PR does
Allows gRPC storage to be used in newer jaeger-query releases when deployed with helm.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
