### PR TITLE
[jaeger] make curl image configurable

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.4.1
+version: 3.4.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -721,7 +721,7 @@ Create image name for hotrod image
 Define curl image declaration
 */}}
 {{- define "curl.image" -}}
-{{- $image := "curlimages/curl" -}}
+{{- $image := .Values.images.curl -}}
 {{- if .Values.global.imageRegistry -}}
 {{ .Values.global.imageRegistry }}/{{ $image }}
 {{- else -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -19,6 +19,9 @@ tag: ""
 nameOverride: ""
 fullnameOverride: ""
 
+images:
+  curl: "curlimages/curl:8.11.1"
+
 allInOne:
   enabled: false
   replicas: 1


### PR DESCRIPTION
#### What this PR does

This PR makes the curl image that is used for elasticsearch configurable and changes it to not use a `latest` tag:

```sh
helm template --set provisionDataStore.elasticsearch=true . | grep curlimages
          image: curlimages/curl:8.11.1
          image: curlimages/curl:8.11.1
```
The tag is configurable via
```
images:
  curl: "curlimages/curl:8.11.1"
```

I am not sure that is the best location in the values.yaml file. I am open for suggestions.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
