### PR TITLE
jaeger: TopologySpreadConstraints

### DIFF
--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -116,6 +116,7 @@ spec:
       {{- with .Values.collector.envFrom }}
         envFrom: {{- toYaml . | nindent 10 }}
       {{- end }}
+    {{- end }
         ports:
         - containerPort: {{ .Values.collector.service.grpc.port }}
           name: grpc
@@ -221,6 +222,10 @@ spec:
     {{- with .Values.collector.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.collector.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
     {{- end }}
     {{- with .Values.collector.tolerations }}
       tolerations:

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -43,6 +43,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.ingester.topologySpreadConstraints }}
+        topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.ingester.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -312,6 +312,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.query.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.query.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -354,6 +354,7 @@ ingester:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -558,6 +559,7 @@ collector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -741,6 +743,7 @@ query:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION


Adds topologySpreadConstraints to the ingester, query and collector helm charts

- fixes #

    N/A

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
