### PR TITLE
[jaeger] TopologySpreadConstraints

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.4.0
+version: 3.4.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/collector-deploy.yaml
+++ b/charts/jaeger/templates/collector-deploy.yaml
@@ -222,6 +222,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.collector.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.collector.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/ingester-deploy.yaml
+++ b/charts/jaeger/templates/ingester-deploy.yaml
@@ -43,6 +43,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.ingester.topologySpreadConstraints }}
+        topologySpreadConstraints:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.ingester.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/templates/query-deploy.yaml
+++ b/charts/jaeger/templates/query-deploy.yaml
@@ -312,6 +312,10 @@ spec:
       affinity:
         {{- toYaml . | nindent 8 }}
     {{- end }}
+    {{- with .Values.query.topologySpreadConstraints }}
+      topologySpreadConstraints:
+      {{- toYaml . | nindent 8 }}
+    {{- end }}
     {{- with .Values.query.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -354,6 +354,7 @@ ingester:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -558,6 +559,7 @@ collector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -741,6 +743,7 @@ query:
   nodeSelector: {}
   tolerations: []
   affinity: {}
+  topologySpreadContraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
Added TopologySpreadConstraints to ingester, collector, query helm charts

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
