### PR TITLE
[jaeger] Fix spelling error of topologySpreadConstraints

### DIFF
--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -89,7 +89,7 @@ allInOne:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podSecurityContext:
     runAsUser: 10001
     runAsGroup: 10001
@@ -354,7 +354,7 @@ ingester:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -559,7 +559,7 @@ collector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -743,7 +743,7 @@ query:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
#### What this PR does

Fixes spelling error of topologySpreadConstraints

#### Which issue this PR fixes

N/A

#### Checklist

- [X] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [X] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [X] Chart Version bumped
- [X] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
