### PR TITLE
[jaeger] patch: adding ability to apply additional labels to the services when not using all-in-one

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 1.53.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.4.1
+version: 3.4.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/agent-svc.yaml
+++ b/charts/jaeger/templates/agent-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: agent
+{{- if .Values.agent.service.labels }}
+    {{- toYaml .Values.agent.service.labels | nindent 4 }}
+{{- end }}
 {{- if .Values.agent.service.annotations }}
   annotations:
     {{- toYaml .Values.agent.service.annotations | nindent 4 }}

--- a/charts/jaeger/templates/collector-svc.yaml
+++ b/charts/jaeger/templates/collector-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: collector
+{{- if .Values.collector.service.labels }}
+    {{- toYaml .Values.collector.service.labels | nindent 4 }}
+{{- end }}
 {{- if .Values.collector.service.annotations }}
   annotations:
     {{- toYaml .Values.collector.service.annotations | nindent 4 }}

--- a/charts/jaeger/templates/hotrod-svc.yaml
+++ b/charts/jaeger/templates/hotrod-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: hotrod
+{{- if .Values.hotrod.service.labels }}
+    {{- toYaml .Values.hotrod.service.labels | nindent 4 }}
+{{- end }}
 {{- if .Values.hotrod.service.annotations }}
   annotations:
     {{- toYaml .Values.hotrod.service.annotations | nindent 4 }}

--- a/charts/jaeger/templates/ingester-svc.yaml
+++ b/charts/jaeger/templates/ingester-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: ingester
+{{- if .Values.ingester.service.labels }}
+    {{- toYaml .Values.ingester.service.labels | nindent 4 }}
+{{- end }}
 {{- if .Values.ingester.service.annotations }}
   annotations:
     {{- toYaml .Values.ingester.service.annotations | nindent 4 }}

--- a/charts/jaeger/templates/query-svc.yaml
+++ b/charts/jaeger/templates/query-svc.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: query
+{{- if .Values.query.service.labels }}
+    {{- toYaml .Values.query.service.labels | nindent 4 }}
+{{- end }}
 {{- if .Values.query.service.annotations }}
   annotations:
     {{- toYaml .Values.query.service.annotations | nindent 4 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -334,6 +334,7 @@ ingester:
     # targetMemoryUtilizationPercentage: 80
   service:
     annotations: {}
+    labels: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
@@ -397,6 +398,7 @@ agent:
       #   maxUnavailable: 1
   service:
     annotations: {}
+    labels: {}
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
     type: ClusterIP
@@ -483,6 +485,7 @@ collector:
     # targetMemoryUtilizationPercentage: 80
   service:
     annotations: {}
+    labels: {}
     # The IP to be used by the load balancer (if supported)
     loadBalancerIP: ""
     # List of IP ranges that are allowed to access the load balancer (if supported)
@@ -692,6 +695,7 @@ query:
   replicaCount: 1
   service:
     annotations: {}
+    labels: {}
     type: ClusterIP
     # List of IP ranges that are allowed to access the load balancer (if supported)
     loadBalancerSourceRanges: []
@@ -1013,6 +1017,7 @@ hotrod:
     pullSecrets: []
   service:
     annotations: {}
+    labels: {}
     name: hotrod
     type: ClusterIP
     # List of IP ranges that are allowed to access the load balancer (if supported)


### PR DESCRIPTION
#### What this PR does
This adds new values so that a user can pass additional labels to the `Services`.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
