### PR TITLE
[jaeger] chore: update to jaeger:1.71.0

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 1.53.0
+appVersion: 1.71.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 3.4.1
+version: 3.5.0
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/_helpers.tpl
+++ b/charts/jaeger/templates/_helpers.tpl
@@ -332,6 +332,8 @@ Cassandra related environment variables
     secretKeyRef:
       name: {{ if .Values.storage.cassandra.existingSecret }}{{ .Values.storage.cassandra.existingSecret }}{{- else }}{{ include "jaeger.fullname" . }}-cassandra{{- end }}
       key: password
+- name: CASSANDRA_BASIC_ALLOWED_AUTHENTICATORS
+  value: org.apache.cassandra.auth.PasswordAuthenticator
 {{- range $key, $value := .Values.storage.cassandra.env }}
 - name: {{ $key | quote }}
   value: {{ $value | quote }}


### PR DESCRIPTION
#### What this PR does

Updates the chart to use jaeger:1.71.0. If used with Cassandra the env variable `CASSANDRA_BASIC_ALLOWED_AUTHENTICATORS` needs to be set, otherwise gocql cannot connect to Cassandra.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [x] README.md has been updated to match version/contain new values
