### PR TITLE
[ci] bump Python version from 3.7 to 3.11 in Helm lint workflow

### DIFF
--- a/.github/actions/prepare-k8s/action.yaml
+++ b/.github/actions/prepare-k8s/action.yaml
@@ -10,9 +10,9 @@ runs:
     # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
     # yamllint (https://github.com/adrienverge/yamllint) which require Python
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.11'
 
     - name: Set up chart-testing
       uses: helm/chart-testing-action@v2.6.1

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -18,9 +18,9 @@ jobs:
       # Python is required because `ct lint` runs Yamale (https://github.com/23andMe/Yamale) and
       # yamllint (https://github.com/adrienverge/yamllint) which require Python
       - name: Set up Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.11'
 
       - name: Set up chart-testing
         uses: helm/chart-testing-action@v2.6.1


### PR DESCRIPTION
#### What this PR does
Replaces the actions/setup-python@v2 step configured with python-version: 3.7
Updates it to actions/setup-python@v4 with python-version: '3.11'

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
