### PR TITLE
[jaeger] Add Default Probes path values for Jaeger

### DIFF
--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -1123,6 +1123,10 @@ hotrod:
   tracing:
     host: null
     port: 6831
+  livenessProbe:
+    path: /
+  readinessProbe:
+    path: / 
 
 # Array with extra yaml objects to install alongside the chart. Values are evaluated as a template.
 extraObjects: []


### PR DESCRIPTION
#### What this PR does
- Adds default base path values 
- Encountered nil pointer bug because interface is not initiated 

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
