### PR TITLE
[jaeger] Set UI-Config for jaeger allInOne deployment

### DIFF
--- a/charts/jaeger/templates/allinone-deploy.yaml
+++ b/charts/jaeger/templates/allinone-deploy.yaml
@@ -49,6 +49,10 @@ spec:
             - name: SAMPLING_STRATEGIES_FILE
               value: /etc/conf/strategies.json
             {{- end }}
+            {{- if .Values.uiconfig }}
+            - name: QUERY_UI_CONFIG
+              value: /etc/jaeger/ui-config/ui-config.json
+            {{- end }}
         {{- with .Values.allInOne.envFrom }}
           envFrom: {{- toYaml . | nindent 12 }}
         {{- end }}
@@ -58,9 +62,9 @@ spec:
           imagePullPolicy: {{ .Values.allInOne.image.pullPolicy }}
           name: jaeger
           args:
-            {{ if .Values.userconfig }}
-             - "--config"
-             - "/etc/jaeger/user-config.yaml"
+            {{- if .Values.userconfig }}
+            - "--config"
+            - "/etc/jaeger/user-config.yaml"
             {{- end }}
             {{- range $arg := .Values.allInOne.args }}
             - "{{ tpl $arg $ }}"
@@ -111,9 +115,13 @@ spec:
         {{- toYaml . | nindent 12 }}
       {{- end }}
           volumeMounts:
-        {{ if .Values.userconfig }}  
+        {{- if .Values.userconfig }}  
             - name: user-config
               mountPath: /etc/jaeger
+        {{- end }}
+        {{- if .Values.uiconfig }}  
+            - name: ui-config
+              mountPath: /etc/jaeger/ui-config
         {{- end }}
         {{- if not .Values.storage.badger.ephemeral }}
             - name: badger-data
@@ -133,10 +141,15 @@ spec:
         {{- toYaml .Values.allInOne.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
       volumes:
-      {{ if .Values.userconfig }}
-         - name: user-config
-           configMap:
+      {{- if .Values.userconfig }}
+        - name: user-config
+          configMap:
             name: user-config
+      {{- end }}
+      {{- if .Values.uiconfig }}
+        - name: ui-config
+          configMap:
+            name: ui-config
       {{- end }}
     {{- if not .Values.storage.badger.ephemeral }}
         - name: badger-data

--- a/charts/jaeger/templates/user-config.yaml
+++ b/charts/jaeger/templates/user-config.yaml
@@ -11,3 +11,17 @@ data:
   user-config.yaml: |
     {{- .Values.userconfig | nindent 4 }}
 {{- end }}
+---
+# Generates a config map from a file provided by user via `--set-file uiconfig=`
+{{- if .Values.uiconfig }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ui-config
+  namespace: {{ include "jaeger.namespace" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+data:
+  ui-config.json: |
+    {{- .Values.uiconfig | nindent 4 }}
+{{- end }}


### PR DESCRIPTION
#### What this PR does
- So , We lacked the capability to mount ui-configs ( which are different from jaeger config.yaml )
- The functionality was provided for jaeger-query and other components but not allInOne 
- Added a configMap and mounting the ui-config to the deployment 

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
