### PR TITLE
[jaeger] Fix typo: topologySpreadContraints -> topologySpreadConstraints in values.yaml

### DIFF
--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -89,7 +89,7 @@ allInOne:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podSecurityContext:
     runAsUser: 10001
     runAsGroup: 10001
@@ -354,7 +354,7 @@ ingester:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -559,7 +559,7 @@ collector:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
@@ -743,7 +743,7 @@ query:
   nodeSelector: {}
   tolerations: []
   affinity: {}
-  topologySpreadContraints: []
+  topologySpreadConstraints: []
   podAnnotations: {}
   ## Additional pod labels
   ## ref: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/


### PR DESCRIPTION
#### What this PR does
Fixes a typo in `values.yaml`:
`topologySpreadContraints` -> `topologySpreadConstraints`

#### Which issue this PR fixes

#### Checklist
- [x] DCO signed
- [ ] Commits are GPG signed
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]`)
- [ ] README.md has been updated to match version/contain new values
