### PR TITLE
[jaeger] Add the ability to set labels and annotations on the services

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.13.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.2.2
+version: 4.2.3
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/service.yaml
+++ b/charts/jaeger/templates/service.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     {{- include "jaeger.labels" . | nindent 4 }}
     app.kubernetes.io/component: all-in-one
+    {{- if .Values.jaeger.service.labels }}
+      {{- toYaml .Values.jaeger.service.labels | nindent 4 }}
+    {{- end }}
   {{- if .Values.jaeger.service.annotations }}
   annotations:
     {{- toYaml .Values.jaeger.service.annotations | nindent 4 }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -129,6 +129,8 @@ jaeger:
     annotations: {}
     automountServiceAccountToken: true
   service:
+    # labels: {}
+    # annotations: {}
     headless: true
     collector:
       otlp:


### PR DESCRIPTION
#### What this PR does
This adds new values so that a user can pass additional labels and annotations to the Services for query,agent and collector.
#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
