### PR TITLE
[jaeger ]Use subPath for mounting user and ui configs

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.0
+version: 4.4.1
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -95,11 +95,13 @@ spec:
           volumeMounts:
         {{- if .Values.userconfig }}
             - name: user-config
-              mountPath: /etc/jaeger/user-config
+              mountPath: /etc/jaeger/user-config.yaml
+              subPath: user-config.yaml
         {{- end }}
         {{- if .Values.uiconfig }}
             - name: ui-config
-              mountPath: /etc/jaeger/ui-config
+              mountPath: /etc/jaeger/ui-config.json
+              subPath: ui-config.json
         {{- end }}
       securityContext:
         {{- toYaml .Values.jaeger.podSecurityContext | nindent 8 }}


### PR DESCRIPTION
#### What this PR does

- Fixes jaeger-deploy.yaml template to use subPath for mounting user-config and ui-config files. Currently files are mounted in user-config and ui-config directories respectively which brakes config load command.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
