### PR TITLE
add ability to set env vars in jaeger for things like OTEL vars

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -36,3 +36,14 @@ jobs:
       - uses: ./.github/actions/prepare-k8s
 
       - run: make test
+
+  test-jaeger-env-vars:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: ./.github/actions/prepare-k8s
+
+      - run: make test-jaeger-env-vars

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,11 @@ lint:
 .PHONY: test
 test:
 	ct install --config ct.yaml
+
+.PHONY: test-jaeger-env-vars
+test-jaeger-env-vars:
+	ct install --config ct.yaml \
+		--charts charts/jaeger \
+		--helm-extra-set-args " \
+		--set jaeger.extraEnv[0].name=OTEL_TRACES_SAMPLER \
+		--set jaeger.extraEnv[0].value=always_off"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.1
+version: 4.4.2
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:

--- a/charts/jaeger/templates/NOTES.txt
+++ b/charts/jaeger/templates/NOTES.txt
@@ -17,6 +17,6 @@ To access the query UI:
   {{- end }}
 {{- else }}
   export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/instance={{ .Release.Name }},app.kubernetes.io/component=all-in-one" -o jsonpath="{.items[0].metadata.name}")
-  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 16686:16686
+  kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 16686:16686 --address 0.0.0.0 &
   Visit http://127.0.0.1:16686/
 {{- end }}

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -32,7 +32,11 @@ spec:
     spec:
       {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       containers:
-        - securityContext:
+        - env:
+          {{- if .Values.jaeger.extraEnv }}
+            {{- toYaml .Values.jaeger.extraEnv | nindent 10 }}
+          {{- end }}
+          securityContext:
             {{- toYaml .Values.jaeger.securityContext | nindent 12 }}
           image: {{ include "jaeger.image" . }}
           imagePullPolicy: {{ .Values.jaeger.image.pullPolicy }}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -157,6 +157,9 @@ jaeger:
     digest: ""
     pullPolicy: IfNotPresent
     pullSecrets: []
+  extraEnv: []
+    # - name: OTEL_TRACES_SAMPLER
+    #   value: "always_off"
   # command line arguments / CLI flags
   # See https://www.jaegertracing.io/docs/cli/
   args: []


### PR DESCRIPTION
#### What this PR does
add env vars to jaeger via chart values

#### Which issue this PR fixes
https://github.com/jaegertracing/helm-charts/issues/727

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #https://github.com/jaegertracing/helm-charts/issues/727

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
