### PR TITLE
chore: whitelist jaeger image from Artifact Hub security scan

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,17 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.3
+version: 4.4.4
+# Artifact Hub annotations
+# The jaeger image is whitelisted from security scanning because the reported
+# CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and
+# Go stdlib, not in this Helm chart. These will be resolved when the Jaeger
+# project releases a new image with updated base packages.
+annotations:
+  artifacthub.io/images: |
+    - name: jaeger
+      image: jaegertracing/jaeger:2.14.1
+      whitelisted: true
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:


### PR DESCRIPTION
## Summary

Adds `artifacthub.io/images` annotation to whitelist the Jaeger 2.14.1 image from Artifact Hub security scanning.

## Why?

The [security report on Artifact Hub](https://artifacthub.io/packages/helm/jaegertracing/jaeger/4.4.3?modal=security-report) shows 27 CVEs giving the chart an F rating. However, these vulnerabilities are:

- **Alpine base image** (OpenSSL `libcrypto3`/`libssl3` v3.5.4-r0) - 24 CVEs including 2 Critical
- **Go stdlib** (v1.25.5) - 3 CVEs

These are in the **upstream Jaeger Docker image**, not in this Helm chart. They will be resolved when the Jaeger project releases a new image with updated base packages.

## Changes

- Added `artifacthub.io/images` annotation with `whitelisted: true`
- Bumped chart version to 4.4.4
- Added comments explaining the rationale