### PR TITLE
Revert: whitelist jaeger image from Artifact Hub security scan

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,17 +3,7 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.4
-# Artifact Hub annotations
-# The jaeger image is whitelisted from security scanning because the reported
-# CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and
-# Go stdlib, not in this Helm chart. These will be resolved when the Jaeger
-# project releases a new image with updated base packages.
-annotations:
-  artifacthub.io/images: |
-    - name: jaeger
-      image: jaegertracing/jaeger:2.14.1
-      whitelisted: true
+version: 4.4.5
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:


### PR DESCRIPTION
## Reverts #731

The whitelist approach just hides the security vulnerabilities for all users rather than fixing the root cause.

The proper fix is to wait for the Jaeger project to release a new image with:
- Updated Alpine base (OpenSSL 3.5.5-r0+)
- Updated Go stdlib (1.25.6+ or 1.24.12+)

Once that happens, we'll update the appVersion and the security rating will improve naturally.