### PR TITLE
chore: whitelist jaeger 2.14.1 image from Artifact Hub security scan

### DIFF
--- a/charts/jaeger/Chart.lock
+++ b/charts/jaeger/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.31.4
-digest: sha256:812f9bf703b331dab00cc69ac348f6b1c021e479cbf1bdc0b788da8763c02062
-generated: "2026-01-16T23:08:17.260569327Z"
+  version: 2.34.0
+digest: sha256:63de10c1f68bedef391890484e1e29f2efd54e6dc7239ca60f0a572042efd4f3
+generated: "2026-02-03T13:47:26.844621Z"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,18 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.6
+version: 4.4.7
+# Artifact Hub annotations
+# The jaeger image is whitelisted from security scanning because the reported
+# CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and
+# Go stdlib, not in this Helm chart. These will be resolved when the Jaeger
+# project releases a new image with updated base packages.
+annotations:
+  artifacthub.io/images: |
+    - name: jaeger
+      image: jaegertracing/jaeger:2.14.1
+      whitelisted: true
+      ignored: true
 # CronJobs require v1.21
 kubeVersion: ">= 1.21-0"
 keywords:


### PR DESCRIPTION
This PR adds Artifact Hub annotations to whitelist and ignore the `jaegertracing/jaeger:2.14.1` image from security scanning.

The security report on Artifact Hub currently shows several CVEs, which are primarily located in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and the Go standard library, rather than in the Helm chart itself. These will be addressed when the Jaeger project releases an updated image.

Summary of changes:
- Added `artifacthub.io/images` annotation to [charts/jaeger/Chart.yaml](charts/jaeger/Chart.yaml)
- Whitelisted and ignored `jaegertracing/jaeger:2.14.1`
- Bumped chart version to `4.4.7`