### PR TITLE
[jaeger] Add extraVolumes/extraVolumeMounts to deployment

### DIFF
--- a/charts/jaeger/Chart.lock
+++ b/charts/jaeger/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.34.0
-digest: sha256:63de10c1f68bedef391890484e1e29f2efd54e6dc7239ca60f0a572042efd4f3
-generated: "2026-02-03T13:47:26.844621Z"
+  version: 2.36.0
+digest: sha256:a9e48d71c1ab826e89a4115379550999c1787634d834acfe22122560393685b4
+generated: "2026-02-10T19:36:02.0023006+01:00"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.14.1
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.4.7
+version: 4.4.8
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -111,6 +111,9 @@ spec:
               mountPath: /etc/jaeger/ui-config.json
               subPath: ui-config.json
         {{- end }}
+        {{- with .Values.jaeger.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
       securityContext:
         {{- toYaml .Values.jaeger.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
@@ -124,6 +127,9 @@ spec:
         - name: ui-config
           configMap:
             name: ui-config
+      {{- end }}
+      {{- with .Values.jaeger.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.jaeger.affinity }}
       affinity:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -217,6 +217,13 @@ jaeger:
     runAsGroup: 10001
     fsGroup: 10001
   securityContext: {}
+  extraVolumes: []
+    # - name: badger-data
+    #   persistentVolumeClaim:
+    #     claimName: jaeger-badger-data
+  extraVolumeMounts: []
+    # - name: badger-data
+    #   mountPath: /badger
 
 # ------------------------------------------------------------------------------
 # Storage Connection Settings


### PR DESCRIPTION
## Summary
- Adds `extraVolumes` and `extraVolumeMounts` fields to the `jaeger` deployment values, restoring the ability to mount custom volumes (PVCs, secrets, configmaps, etc.) on the Jaeger pod
- The v4.2.0 chart rewrite simplified the deployment to only support ConfigMap volumes for user-config and ui-config, which broke storage backends like Badger that require persistent volumes
- Follows the same pattern already used by `spark`, `esIndexCleaner`, `esRollover`, and `esLookback` job templates

Fixes #737

## Test plan
- [x] `helm lint charts/jaeger` passes
- [x] `helm template` renders correctly with default values (no extra volumes)
- [x] `helm template` renders correctly with extra volumes/mounts set (PVC and mountPath appear in output)
- [x] CI values files render cleanly