### PR TITLE
[jaeger] Add support for podAnnotations to all-in-one deployment

### DIFF
--- a/charts/jaeger/Chart.lock
+++ b/charts/jaeger/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: common
   repository: https://charts.bitnami.com/bitnami
-  version: 2.34.0
-digest: sha256:63de10c1f68bedef391890484e1e29f2efd54e6dc7239ca60f0a572042efd4f3
-generated: "2026-02-03T13:47:26.844621Z"
+  version: 2.36.0
+digest: sha256:a9e48d71c1ab826e89a4115379550999c1787634d834acfe22122560393685b4
+generated: "2026-02-11T16:40:36.0392565+01:00"

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.19.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.11.1
+version: 4.11.2
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -36,8 +36,9 @@ spec:
         {{- toYaml .Values.jaeger.podLabels | nindent 8 }}
 {{- end }}
       annotations:
-        prometheus.io/port: "8888"
-        prometheus.io/scrape: "true"
+        {{- if .Values.jaeger.podAnnotations }}
+        {{- toYaml .Values.jaeger.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
       {{- include "jaeger.imagePullSecrets" . | nindent 6 }}
       containers:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -239,6 +239,9 @@ jaeger:
   tolerations: []
   affinity: {}
   topologySpreadContraints: []
+  podAnnotations:
+    prometheus.io/port: "8888"
+    prometheus.io/scrape: "true"
   podSecurityContext:
     runAsUser: 10001
     runAsGroup: 10001


### PR DESCRIPTION
## Summary

Currently, the `all-in-one` deployment template has a hardcoded `annotations` block. This prevents users from injecting critical metadata required by various ecosystem tools that rely on Pod-level annotations.

### Example Use Cases

* **Consul Service Mesh:** Requires `consul.hashicorp.com/connect-inject` to inject sidecar proxies for secure mTLS communication (e.g., securing OTLP traffic on TCP port 4317).
* **Custom Metrics Scrapers:** While Prometheus annotations are hardcoded, users may have custom scraping requirements or use alternative observability platforms (like Datadog or New Relic) that require specific pod-level tags.

### Changes

* This adds the `podAnnotations` field to the jaeger values section and its usage to the `all-in-one` deployment template.
* Move the default configuration for prometheus scraping setup from the template to the values.
* Ensured usage of the same pattern as the  spark, esIndexCleaner, esRollover, and esLookback job templates.
* The legacy components such as `query` supported `podAnnotations` the same way the other components still do.

### Checklist

- [x] helm lint charts/jaeger passes
- [x] helm template renders correctly with default values (no extra extra annotations on pod level)
- [x] helm template renders correctly with extra annotations set (pod annotations appear in output)
- [x] CI values files render cleanly