### PR TITLE
[jaeger] Add extraSecretMounts to jaeger

### DIFF
--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -111,6 +111,13 @@ spec:
               mountPath: /etc/jaeger/ui-config.json
               subPath: ui-config.json
         {{- end }}
+        {{- if .Values.jaeger.extraSecretMounts }}
+        {{- range .Values.jaeger.extraSecretMounts }}
+            - name: {{ .name }}
+              mountPath: {{ .mountPath }}
+              readOnly: {{ .readOnly }}
+        {{- end }}
+        {{- end }}
       securityContext:
         {{- toYaml .Values.jaeger.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
@@ -124,6 +131,13 @@ spec:
         - name: ui-config
           configMap:
             name: ui-config
+      {{- end }}
+      {{- if .Values.jaeger.extraSecretMounts }}
+      {{- range .Values.jaeger.extraSecretMounts }}
+        - name: {{ .name }}
+          csi:
+            {{- toYaml .csi | nindent 12 }}
+      {{- end }}
       {{- end }}
     {{- with .Values.jaeger.affinity }}
       affinity:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -168,6 +168,7 @@ jaeger:
     #   value: "always_off"
   # command line arguments / CLI flags
   # See https://www.jaegertracing.io/docs/cli/
+  extraSecretMounts: []
   args: []
   serviceAccount:
     annotations: {}


### PR DESCRIPTION
## Description
This PR introduces the `extraSecretMounts` capability to the Jaeger deployment chart. 

Currently, users relying on external secret management tools like HashiCorp Vault via the Secrets Store CSI Driver face limitations because there is no native way to attach these external volumes directly to the Jaeger pods without complex workarounds (like creating auxiliary pause pods). 

Similar to the implementation in [`kube-prometheus-stack`](https://github.com/prometheus-community/helm-charts/tree/main/charts/kube-prometheus-stack), this feature allows users to easily define secret mounts in their `values.yaml`, and the template automatically handles both the `volumes` and `volumeMounts` configurations.

**Related Issues:**
* Fixes #735
* Resolves #737

## Changes Made
* Added `extraSecretMounts` block parsing to `jaeger/templates/jaeger/jaeger-deploy.yaml` (handles both `volumeMounts` and `volumes`).
* Added an empty `extraSecretMounts: []` list to `jaeger/values.yaml` to ensure backward compatibility and serve as documentation.

## How to Test
You can test this by adding the following block to your `values.yaml` and running `helm template`:

```yaml
jaeger:
  extraSecretMounts:
    - name: secrets-store-inline
      mountPath: "/mnt/secrets-store"
      readOnly: true
      csi:
        driver: secrets-store.csi.k8s.io
        readOnly: true
        volumeAttributes:
          secretProviderClass: "vault-jaeger-creds"