### PR TITLE
Add port 8889

### DIFF
--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -76,6 +76,8 @@ spec:
               protocol: TCP
             - containerPort: 8888
               protocol: TCP
+            - containerPort: 8889
+              protocol: TCP
           livenessProbe:
             failureThreshold: 5
             httpGet:


### PR DESCRIPTION
Add port 8889 on deployment to export span-metrics

#### What this PR does

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
