### PR TITLE
Adding support for custom deployment strategy.

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.17.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.7.0
+version: 4.7.1
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 2.17.0
+appVersion: 2.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.7.0
+version: 4.8.0
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and
@@ -12,7 +12,7 @@ version: 4.7.0
 annotations:
   artifacthub.io/images: |
     - name: jaeger
-      image: jaegertracing/jaeger:2.17.0
+      image: jaegertracing/jaeger:2.18.0
       whitelisted: true
       ignored: true
 # CronJobs require v1.21

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -16,8 +16,13 @@ spec:
   {{- if hasKey .Values.jaeger "replicas" }}
   replicas: {{ .Values.jaeger.replicas }}
   {{- end }}
+  {{- if .Values.jaeger.strategy }}
+  strategy:
+    {{- toYaml .Values.jaeger.strategy | nindent 4 }}
+  {{- else }}
   strategy:
     type: Recreate
+  {{- end }}
   selector:
     matchLabels:
       {{- include "jaeger.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
#### What this PR does
Provides the ability to choose a deployment strategy for the Jaeger Helm chart.

#### Which issue this PR fixes

*(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format,
will close that issue when PR gets merged)*

- fixes #

#### Checklist

- [ ] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [ ] Chart Version bumped
- [ ] Title of the PR starts with chart name (`[jaeger]` or `[jaeger-operator]`)
- [ ] README.md has been updated to match version/contain new values
