### PR TITLE
[jaeger] Add Gateway API HTTPRoute support for the Query UI

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.18.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.8.0
+version: 4.9.0
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/README.md
+++ b/charts/jaeger/README.md
@@ -171,6 +171,7 @@ For a full list of supported environment variables, see the [Spark Dependencies 
 To access the ui you can either:
 
 * enable the ingress and fill at least one host
+* enable the Gateway API HTTPRoute and attach it to an existing Gateway
 * provide your own ingress
 * or port forward ```kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME 16686:16686 --address 0.0.0.0``` and access at http://localhost:16686/
 
@@ -179,6 +180,19 @@ jaeger:
   ingress:
     enabled: true
     hosts:
+      - <fill a host here>
+```
+
+Alternatively, expose the Query UI through the [Gateway API](https://gateway-api.sigs.k8s.io/). This requires the Gateway API CRDs and a `Gateway` to already exist in the cluster:
+
+```yaml
+jaeger:
+  httproute:
+    enabled: true
+    parentRefs:
+      - name: <your-gateway-name>
+        namespace: <your-gateway-namespace>
+    hostnames:
       - <fill a host here>
 ```
 

--- a/charts/jaeger/templates/jaeger/jaeger-httproute.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-httproute.yaml
@@ -1,5 +1,8 @@
 {{- if and (.Values.jaeger.enabled) (.Values.jaeger.httproute.enabled) -}}
 {{- $route := .Values.jaeger.httproute -}}
+{{- if not $route.parentRefs -}}
+{{- fail "jaeger.httproute.enabled is true but jaeger.httproute.parentRefs is empty; an HTTPRoute needs at least one parentRef to attach to a Gateway" -}}
+{{- end -}}
 apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
 kind: HTTPRoute
 metadata:

--- a/charts/jaeger/templates/jaeger/jaeger-httproute.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-httproute.yaml
@@ -1,0 +1,38 @@
+{{- if and (.Values.jaeger.enabled) (.Values.jaeger.httproute.enabled) -}}
+{{- $route := .Values.jaeger.httproute -}}
+apiVersion: {{ $route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: HTTPRoute
+metadata:
+  name: {{ template "jaeger.fullname" . }}
+  labels:
+    {{- include "jaeger.labels" . | nindent 4 }}
+    app.kubernetes.io/component: all-in-one
+  {{- with include "jaeger.annotations" (dict "context" . "component" $route.annotations) }}
+  annotations:
+    {{- . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with $route.hostnames }}
+  hostnames:
+    {{- tpl (toYaml .) $ | nindent 4 }}
+  {{- end }}
+  rules:
+    {{- with $route.additionalRules }}
+    {{- tpl (toYaml .) $ | nindent 4 }}
+    {{- end }}
+    - backendRefs:
+        - name: {{ include "jaeger.fullname" . }}
+          port: 16686
+      {{- with $route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with $route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end -}}

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -201,6 +201,33 @@ jaeger:
     #     hosts:
     #       - chart-example.local
     pathType:
+  httproute:
+    # Create an HTTPRoute (Gateway API) to expose the Jaeger Query UI (port 16686).
+    # Requires the Gateway API CRDs to be installed in the cluster.
+    enabled: false
+    # HTTPRoute apiVersion (defaults to "gateway.networking.k8s.io/v1" when empty)
+    apiVersion: ""
+    annotations: {}
+    # parentRefs reference the Gateway(s) this HTTPRoute is attached to
+    # parentRefs:
+    #   - name: my-gateway
+    #     namespace: gateway-system
+    #     sectionName: http
+    parentRefs: []
+    # hostnames matched against the HTTP Host header to select this route
+    # hostnames:
+    #   - chart-example.local
+    hostnames: []
+    # matches define conditions used to match incoming requests against the rule.
+    # Defaults to a PathPrefix "/" match (mirrors the Ingress behavior above).
+    matches:
+      - path:
+          type: PathPrefix
+          value: /
+    # filters applied to requests that match this rule
+    filters: []
+    # additionalRules (templated) prepends custom HTTPRoute rules
+    additionalRules: []
   # resources:
   #   limits:
   #     cpu: 500m


### PR DESCRIPTION
#### What this PR does

Adds optional Gateway API `HTTPRoute` support to the `jaeger` chart, exposing the Query UI (port `16686`) as an alternative to the existing Ingress.

- Disabled by default (`jaeger.httproute.enabled: false`) — existing installs are unaffected and no Gateway API CRDs are required unless it is explicitly enabled.
- The new `jaeger.httproute` values block mirrors the existing `jaeger.ingress` block: `parentRefs`, `hostnames`, `matches` (defaults to `PathPrefix: /`), `filters`, `additionalRules`, custom `annotations`, and an `apiVersion` override.
- The template reuses the chart's `jaeger.fullname` / `jaeger.labels` / `jaeger.annotations` helpers and targets the same Query UI port (`16686`) as the Ingress.
- `README.md` "Query UI" section and `values.yaml` comments document the new option.

Chart `version` bumped `4.8.0` → `4.9.0`.

#### Validation

- `ct lint --config ct.yaml --charts charts/jaeger` passes (Chart.yaml schema valid, version bump detected, `ci/default-values.yaml` lint clean).
- `helm lint charts/jaeger` passes.
- `helm template` verified: HTTPRoute is not rendered by default; renders a valid `gateway.networking.k8s.io/v1` HTTPRoute when enabled (with `parentRefs` / `hostnames` / `matches` / `filters` / `apiVersion` override); `commonAnnotations` propagate; the existing Ingress still renders unchanged.

#### Which issue this PR fixes

N/A — additive feature.

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [ ] Commits are [GPG signed](https://docs.github.com/en/github/authenticating-to-github/about-commit-signature-verification)
- [x] Chart Version bumped (`4.8.0` → `4.9.0`)
- [x] Title of the PR starts with chart name (`[jaeger]`)
- [x] README.md has been updated to match version/contain new values
