### PR TITLE
[jaeger] Add extraVolumes and extraVolumeMounts to all-in-one deployment

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.19.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.11.0
+version: 4.11.1
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -118,6 +118,9 @@ spec:
               mountPath: /etc/jaeger/ui-config.json
               subPath: ui-config.json
         {{- end }}
+        {{- with .Values.jaeger.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+        {{- end }}
       securityContext:
         {{- toYaml .Values.jaeger.podSecurityContext | nindent 8 }}
       serviceAccountName: {{ template "jaeger.fullname" . }}
@@ -131,6 +134,9 @@ spec:
         - name: ui-config
           configMap:
             name: ui-config
+      {{- end }}
+      {{- with .Values.jaeger.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
       {{- end }}
     {{- with .Values.jaeger.affinity }}
       affinity:

--- a/charts/jaeger/values.yaml
+++ b/charts/jaeger/values.yaml
@@ -244,6 +244,13 @@ jaeger:
     runAsGroup: 10001
     fsGroup: 10001
   securityContext: {}
+  extraVolumes: []
+    # - name: badger-data
+    #   persistentVolumeClaim:
+    #     claimName: jaeger-badger-data
+  extraVolumeMounts: []
+    # - name: badger-data
+    #   mountPath: /badger
 
 # ------------------------------------------------------------------------------
 # Storage Connection Settings


### PR DESCRIPTION
## Summary
- Adds `extraVolumes` and `extraVolumeMounts` to the all-in-one Jaeger Deployment, restoring the ability to mount PVCs, secrets, and configmaps that the v4.2.0 rewrite removed (only the ConfigMap user-config/ui-config volumes remained).
- Follows the same `{{- with }}` + `toYaml` pattern already used for `affinity` / `topologySpreadConstraints` in the same template.

Fixes #737

Also resolves #735: a self-signed-CA secret for a TLS storage backend can now be mounted via a secret-type `extraVolumes` entry plus `extraVolumeMounts`, restoring the v1 `extraSecretMounts` use case. If maintainers prefer re-adding the dedicated `extraSecretMounts` convenience shape (as used by the spark / es-maintenance jobs), happy to follow up.

## Test plan
- [x] `helm lint charts/jaeger` passes
- [x] `helm template` with default values renders cleanly (no extra volume artifacts)
- [x] `helm template` with `extraVolumes` / `extraVolumeMounts` set renders the PVC and secret mounts correctly
- [x] Both `charts/jaeger/ci/*.yaml` values files render cleanly
- [x] `Chart.yaml` version bumped 4.11.0 -> 4.11.1
