### PR TITLE
[jaeger] Checksum user/ui config to restart all-in-one on change

### DIFF
--- a/charts/jaeger/Chart.yaml
+++ b/charts/jaeger/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 2.19.0
 description: A Jaeger Helm chart for Kubernetes
 name: jaeger
 type: application
-version: 4.11.0
+version: 4.11.1
 # Artifact Hub annotations
 # The jaeger image is whitelisted from security scanning because the reported
 # CVEs are in the upstream Alpine base image (OpenSSL libcrypto3/libssl3) and

--- a/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
+++ b/charts/jaeger/templates/jaeger/jaeger-deploy.yaml
@@ -36,6 +36,8 @@ spec:
         {{- toYaml .Values.jaeger.podLabels | nindent 8 }}
 {{- end }}
       annotations:
+        checksum/user-config: {{ include (print $.Template.BasePath "/jaeger/jaeger-user-config.yaml") . | sha256sum | quote }}
+        checksum/ui-config: {{ include (print $.Template.BasePath "/jaeger/jaeger-ui-config.yaml") . | sha256sum | quote }}
         prometheus.io/port: "8888"
         prometheus.io/scrape: "true"
     spec:


### PR DESCRIPTION
#### What this PR does

The all-in-one Deployment (`templates/jaeger/jaeger-deploy.yaml`) mounts the `user-config` and `ui-config` ConfigMaps via `subPath`, and its pod template carries no checksum annotation. As a result, when `.Values.userconfig` or `.Values.uiconfig` changes, Helm/ArgoCD updates the ConfigMaps but the running pod keeps the old config and is **never restarted** (subPath mounts don't receive in-place updates either).

This adds `checksum/user-config` and `checksum/ui-config` annotations to the pod template, so a change to either config rolls the pod and reloads the new config. This mirrors the approach #246 took for the query UI config, now applied to the v2 all-in-one deployment.

Bumps the `jaeger` chart to `4.11.1` (per the immutability/versioning policy).

#### Testing

- `helm lint` passes.
- `helm template` renders both annotations to concrete SHA256 values in the pod template.
- Verified `checksum/user-config` changes when `userconfig` changes (pod will roll); unchanged config yields a stable checksum (no spurious restarts).

#### Checklist

- [x] [DCO](https://github.com/jaegertracing/helm-charts/blob/main/CONTRIBUTING.md#sign-off-your-work) signed
- [x] Chart Version bumped
- [x] Title of the PR starts with chart name (`[jaeger]`)